### PR TITLE
test!: add simple test for idempotence of `convert_to_markdown()`

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -641,3 +641,9 @@ def test_lang_callback() -> None:
         )
         == "\n```javascript\ntest\n    foo\nbar\n```\n"
     )
+
+
+def test_idempotence() -> None:
+    html_text = "<h2>Header&nbsp;</h2><p>Next paragraph.</p>"
+    converted = convert_to_markdown(html_text)
+    assert converted == convert_to_markdown(converted)


### PR DESCRIPTION
I raised [this issue](https://github.com/Goldziher/html-to-markdown/issues/6) and proposed that `convert_to_markdown()` should be _idempotent_. That is, it shouldn't change a string that was converted from HTML to Markdown by itself before.