### PR TITLE
fix:  ensure eol before headings

### DIFF
--- a/html_to_markdown/processing.py
+++ b/html_to_markdown/processing.py
@@ -89,7 +89,7 @@ def _process_tag(
     escape_misc: bool,
     escape_underscores: bool,
     strip: set[str] | None,
-    context_before: str | None = None,
+    context_before: str = "",
 ) -> str:
     should_convert_tag = _should_convert_tag(tag_name=tag.name, strip=strip, convert=convert)
     tag_name: SupportedTag | None = (

--- a/html_to_markdown/processing.py
+++ b/html_to_markdown/processing.py
@@ -89,6 +89,7 @@ def _process_tag(
     escape_misc: bool,
     escape_underscores: bool,
     strip: set[str] | None,
+    context_before: str = None
 ) -> str:
     should_convert_tag = _should_convert_tag(tag_name=tag.name, strip=strip, convert=convert)
     tag_name: SupportedTag | None = (
@@ -129,12 +130,24 @@ def _process_tag(
                 escape_misc=escape_misc,
                 escape_underscores=escape_underscores,
                 strip=strip,
+                context_before=text[-2:],
             )
 
     if tag_name and should_convert_tag:
-        return converters_map[tag_name](  # type: ignore[call-arg]
+        rendered = converters_map[tag_name](  # type: ignore[call-arg]
             tag=tag, text=text, convert_as_inline=convert_as_inline
         )
+        # For headings, ensure two newlines before if not already present
+        if is_heading:
+            prefix = ""
+            if context_before != "":
+                if not context_before.endswith("\n\n"):
+                    if context_before.endswith("\n"):
+                        prefix = "\n"
+                    else:
+                        prefix = "\n\n"
+            return f"{prefix}{rendered}"
+        return rendered
 
     return text
 
@@ -275,13 +288,25 @@ def convert_to_markdown(
     if custom_converters:
         converters_map.update(cast("ConvertersMap", custom_converters))
 
-    return _process_tag(
-        source,
-        converters_map,
-        convert=_as_optional_set(convert),
-        convert_as_inline=convert_as_inline,
-        escape_asterisks=escape_asterisks,
-        escape_misc=escape_misc,
-        escape_underscores=escape_underscores,
-        strip=_as_optional_set(strip),
-    )
+    result = ""
+    for el in filter(lambda value: not isinstance(value, (Comment, Doctype)), source.children):
+        if isinstance(el, NavigableString):
+            result += _process_text(
+                el=el,
+                escape_misc=escape_misc,
+                escape_asterisks=escape_asterisks,
+                escape_underscores=escape_underscores,
+            )
+        elif isinstance(el, Tag):
+            result += _process_tag(
+                el,
+                converters_map,
+                convert_as_inline=convert_as_inline,
+                convert=_as_optional_set(convert),
+                escape_asterisks=escape_asterisks,
+                escape_misc=escape_misc,
+                escape_underscores=escape_underscores,
+                strip=_as_optional_set(strip),
+                context_before=result[-2:],
+            )
+    return result

--- a/html_to_markdown/processing.py
+++ b/html_to_markdown/processing.py
@@ -89,7 +89,7 @@ def _process_tag(
     escape_misc: bool,
     escape_underscores: bool,
     strip: set[str] | None,
-    context_before: str = None
+    context_before: str | None = None,
 ) -> str:
     should_convert_tag = _should_convert_tag(tag_name=tag.name, strip=strip, convert=convert)
     tag_name: SupportedTag | None = (
@@ -139,9 +139,9 @@ def _process_tag(
         )
         # For headings, ensure two newlines before if not already present
         # Edge case where the document starts with a \n and then a heading
-        if is_heading and context_before != "" and context_before != "\n":
+        if is_heading and context_before not in {"", "\n"}:
             n_eol_to_add = 2 - (len(context_before) - len(context_before.rstrip("\n")))
-            if n_eol_to_add > 0 :
+            if n_eol_to_add > 0:
                 prefix = "\n" * n_eol_to_add
                 return f"{prefix}{rendered}"
         return rendered

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -426,13 +426,16 @@ def test_hn_chained() -> None:
         convert_to_markdown("<h1>First</h1>\n<h2>Second</h2>\n<h3>Third</h3>", heading_style=ATX)
         == "# First\n\n\n## Second\n\n\n### Third\n\n"
     )
-    assert convert_to_markdown("X<h1>First</h1>", heading_style=ATX) == "X# First\n\n"
+    assert convert_to_markdown("X<h1>First</h1>", heading_style=ATX) == "X\n\n# First\n\n"
 
 
 def test_hn_nested_tag_heading_style() -> None:
     assert convert_to_markdown("<h1>A <p>P</p> C </h1>", heading_style=ATX_CLOSED) == "# A P C #\n\n"
     assert convert_to_markdown("<h1>A <p>P</p> C </h1>", heading_style=ATX) == "# A P C\n\n"
 
+def test_hn_eol() -> None:
+    assert convert_to_markdown("<p>xxx</p><h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
+    assert convert_to_markdown("xxx<h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
 
 def test_hn_nested_simple_tag() -> None:
     tag_to_markdown = [

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -435,6 +435,9 @@ def test_hn_nested_tag_heading_style() -> None:
 
 def test_hn_eol() -> None:
     assert convert_to_markdown("<p>xxx</p><h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
+    assert convert_to_markdown("\n<h3>Hello</h3>", heading_style=ATX) == "\n### Hello\n\n"
+    assert convert_to_markdown("\nx<h3>Hello</h3>", heading_style=ATX) == "\nx\n\n### Hello\n\n"
+    assert convert_to_markdown("\n<span>x<h3>Hello</h3></span>", heading_style=ATX) == "\nx\n\n### Hello\n\n"
     assert convert_to_markdown("xxx<h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
 
 def test_hn_nested_simple_tag() -> None:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -433,12 +433,14 @@ def test_hn_nested_tag_heading_style() -> None:
     assert convert_to_markdown("<h1>A <p>P</p> C </h1>", heading_style=ATX_CLOSED) == "# A P C #\n\n"
     assert convert_to_markdown("<h1>A <p>P</p> C </h1>", heading_style=ATX) == "# A P C\n\n"
 
+
 def test_hn_eol() -> None:
     assert convert_to_markdown("<p>xxx</p><h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
     assert convert_to_markdown("\n<h3>Hello</h3>", heading_style=ATX) == "\n### Hello\n\n"
     assert convert_to_markdown("\nx<h3>Hello</h3>", heading_style=ATX) == "\nx\n\n### Hello\n\n"
     assert convert_to_markdown("\n<span>x<h3>Hello</h3></span>", heading_style=ATX) == "\nx\n\n### Hello\n\n"
     assert convert_to_markdown("xxx<h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
+
 
 def test_hn_nested_simple_tag() -> None:
     tag_to_markdown = [


### PR DESCRIPTION
fix for #9 

You may want to control the number of EOL before/after headings within an arg !?

I have ran tests and added some (Had to modify one also)