### PR TITLE
fix: #15: uvx command installation

### DIFF
--- a/html_to_markdown/__main__.py
+++ b/html_to_markdown/__main__.py
@@ -1,6 +1,6 @@
 import sys
 
-if __name__ == "__main__":
+def cli():
     from html_to_markdown.cli import main
 
     try:
@@ -9,3 +9,6 @@ if __name__ == "__main__":
     except ValueError as e:
         print(str(e), file=sys.stderr)  # noqa: T201
         sys.exit(1)
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Topic :: Utilities",
   "Typing :: Typed",
 ]
+scripts.html_to_markdown = "html_to_markdown.__main__:cli"
 
 dependencies = [
   "beautifulsoup4>=4.13.4",
@@ -57,8 +58,6 @@ html_to_markdown = [ "py.typed" ]
 
 [tool.hatch.build]
 skip-excluded-dirs = true
-
-scripts.html_to_markdown = "html_to_markdown.__main__:cli"
 
 [tool.ruff]
 target-version = "py39"


### PR DESCRIPTION
This is a fix for the problem when trying to run the command line tool directly using `uvx` as noted in #15.

The fix moves the `scripts.html_to_markdown` entry to the correct section and provides the required function entry point in the `html_to_markdown.__main__` file.

