### PR TITLE
feat: Automatically create Docker images for containerised command line execution

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,40 @@
+name: Docker Build
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    environment: Build
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ vars.DOCKERHUB_ORGNAME || vars.DOCKERHUB_USERNAME }}/${{ vars.DOCKERHUB_REPO_NAME }}
+          tags: |
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            type=sha
+            type=raw,value=latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile for a containerised instance of the html_to_markdown command line app
+
+FROM cgr.dev/chainguard/python:latest-dev AS dev
+
+COPY . /source
+
+# Install as root, but we run as nonroot
+USER root
+RUN pip install /source
+
+
+# The final image uses the minimal Chainguard version
+FROM cgr.dev/chainguard/python:latest
+COPY --from=dev /usr/lib/python3.13/site-packages /usr/lib/python3.13/site-packages
+
+ENTRYPOINT ["python", "-m", "html_to_markdown"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,11 @@ version = "1.3.2"
 description = "Convert HTML to markdown"
 readme = "README.md"
 keywords = [ "converter", "html", "markdown", "text-extraction", "text-processing" ]
-license = { text = "MIT" }
+license = "MIT"
 authors = [ { name = "Na'aman Hirschfeld", email = "nhirschfeld@gmail.com" } ]
 requires-python = ">=3.9"
 classifiers = [
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This PR addresses issue #14.

The changes here are:
 * Add a Dockerfile for creating containerised command line images that can be executed using `docker run`.
 * Update the pyproject.toml to meet the latest standards for specifying licence terms.
 * Add a new workflow to perform Docker builds and push them to DockerHub.

Images are built using (free) [Chainguard](https://www.chainguard.dev) Python base images to maximise security and minimise image size.

The automatic pushing of images to DockerHub requires an Actions environment called `Build` to exist and for it to contain the following environment variables and secret:

* `DOCKERHUB_USERNAME`: the user name of the account used to upload the images.
* `DOCKERHUB_REPO_NAME`: the of the images (e.g. `html-to-markdown`).
* `DOCKERHUB_ORGNAME`: this may optionally also be set if you want to push the image to a namespace that is different to the name of the user of the user; if it is not set the workflow defaults to the user's namespace.
* `DOCKERHUB_TOKEN`: a ***secret*** (rather than an environment variable) containing a user token with permission to write to the namespace and repo specified.

The workflow will build Docker images for both `amd64` and `arm64` platforms.