### PR TITLE
Add <mark> tag support and fix pipe chain test for Windows

### DIFF
--- a/html_to_markdown/converters.py
+++ b/html_to_markdown/converters.py
@@ -56,6 +56,7 @@ SupportedElements = Literal[
     "th",
     "tr",
     "kbd",
+    "mark",
 ]
 
 Converter = Callable[[str, Tag], str]
@@ -230,6 +231,21 @@ def _convert_p(*, wrap: bool, text: str, convert_as_inline: bool, wrap_width: in
 
     return f"{text}\n\n" if text else ""
 
+def _convert_mark(*, text: str, convert_as_inline: bool) -> str:
+    if convert_as_inline:
+        return text
+
+    # You can modify this logic later to read from options if needed
+    highlight_style = "double-equal"  # Could be "html" or "bold" optionally
+
+    if highlight_style == "double-equal":
+        return f"=={text}=="
+    elif highlight_style == "bold":
+        return f"**{text}**"
+    elif highlight_style == "html":
+        return f"<mark>{text}</mark>"
+    else:
+        return text
 
 def _convert_pre(
     *,
@@ -363,6 +379,7 @@ def create_converters_map(
         "ol": _wrapper(_convert_list),
         "li": _wrapper(partial(_convert_li, bullets=bullets)),
         "p": _wrapper(partial(_convert_p, wrap=wrap, wrap_width=wrap_width)),
+        "mark": _wrapper(_convert_mark),
         "pre": _wrapper(
             partial(
                 _convert_pre,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -548,6 +548,11 @@ def test_p() -> None:
         == "12345678901\\\n12345\n\n"
     )
 
+def test_mark_tag():
+    html = "<mark>highlighted</mark>"
+    expected = "==highlighted=="
+    assert convert_to_markdown(html).strip() == expected
+
 
 def test_pre() -> None:
     assert convert_to_markdown("<pre>test\n    foo\nbar</pre>") == "\n```\ntest\n    foo\nbar\n```\n"

--- a/tests/module_test.py
+++ b/tests/module_test.py
@@ -21,6 +21,7 @@ def run_cli_command(args: list[str], input_text: str | None = None, timeout: int
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8", 
     )
 
     try:
@@ -225,25 +226,18 @@ def test_multiple_files(sample_html_file: Path, complex_html_file: Path, tmp_pat
 def test_pipe_chain() -> None:
     """Test the CLI in a pipe chain."""
 
-    echo_process = subprocess.Popen(["echo", "<h1>Test</h1>"], stdout=subprocess.PIPE, text=True)
-
-    html_to_md_process = subprocess.Popen(
-        [sys.executable, "-m", "html_to_markdown"], stdin=echo_process.stdout, stdout=subprocess.PIPE, text=True
+    html_input = "<h1>Test</h1>"
+    process = subprocess.Popen(
+        [sys.executable, "-m", "html_to_markdown"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
     )
 
-    grep_process = subprocess.Popen(
-        ["grep", "Test"], stdin=html_to_md_process.stdout, stdout=subprocess.PIPE, text=True
-    )
+    output, _ = process.communicate(input=html_input)
 
-    if echo_process.stdout:
-        echo_process.stdout.close()
-
-    if html_to_md_process.stdout:
-        html_to_md_process.stdout.close()
-
-    output = grep_process.communicate()[0]
     assert "Test" in output
-    assert grep_process.returncode == 0
 
 
 @pytest.mark.parametrize("newline_style", ["spaces", "backslash"])


### PR DESCRIPTION
### What’s Changed
- Added support for the `<mark>` HTML tag by updating `converters.py`
- Fixed the `test_pipe_chain` function to work on Windows by removing the `grep` subprocess and capturing the output directly from the CLI.

### Why It Matters
- The `<mark>` tag was previously unhandled.
- The pipe chain test was failing on Windows due to reliance on Unix-specific commands.

### Related Issues
Fixes #954 (add mark support)
Fixes #956 (pipe chain test fails on Windows)

---

Let me know if you'd like any changes to the PR!
