### PR TITLE
feat: add media element converters (audio, video, iframe)

### DIFF
--- a/html_to_markdown/processing.py
+++ b/html_to_markdown/processing.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Mapping
     # Use the imported PageElement instead of re-importing
 from io import StringIO
+import re
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
@@ -30,6 +31,7 @@ SupportedTag = Literal[
     "a",
     "article",
     "aside",
+    "audio",
     "b",
     "blockquote",
     "br",
@@ -51,6 +53,7 @@ SupportedTag = Literal[
     "header",
     "hr",
     "i",
+    "iframe",
     "img",
     "input",
     "kbd",
@@ -79,6 +82,7 @@ SupportedTag = Literal[
     "td",
     "th",
     "tr",
+    "video",
 ]
 
 
@@ -470,10 +474,17 @@ def convert_to_markdown(
                 context_before=text[-2:],
             )
 
-    # Prepend metadata comment if extracted
-    if metadata_comment:
-        return metadata_comment + text
-    return text
+    # Combine metadata and text
+    result = metadata_comment + text if metadata_comment else text
+
+    # Normalize excessive newlines - max 2 consecutive newlines (one empty line)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+
+    # Strip all trailing newlines in inline mode
+    if convert_as_inline:
+        result = result.rstrip("\n")
+
+    return result
 
 
 class StreamingProcessor:

--- a/tests/media_elements_test.py
+++ b/tests/media_elements_test.py
@@ -1,0 +1,249 @@
+"""Tests for media element functionality (audio, video, iframe)."""
+
+from html_to_markdown import convert_to_markdown
+
+
+def test_audio_basic() -> None:
+    """Test basic audio element conversion."""
+    html = '<audio src="audio.mp3"></audio>'
+    result = convert_to_markdown(html)
+    assert result == '<audio src="audio.mp3" />\n\n'
+
+
+def test_audio_with_controls() -> None:
+    """Test audio element with controls attribute."""
+    html = '<audio src="audio.mp3" controls></audio>'
+    result = convert_to_markdown(html)
+    assert result == '<audio src="audio.mp3" controls />\n\n'
+
+
+def test_audio_with_all_attributes() -> None:
+    """Test audio element with all common attributes."""
+    html = '<audio src="audio.mp3" controls autoplay loop muted preload="auto"></audio>'
+    result = convert_to_markdown(html)
+    assert result == '<audio src="audio.mp3" controls autoplay loop muted preload="auto" />\n\n'
+
+
+def test_audio_with_source_element() -> None:
+    """Test audio with source child element."""
+    html = """<audio controls>
+    <source src="audio.mp3" type="audio/mpeg">
+    <source src="audio.ogg" type="audio/ogg">
+</audio>"""
+    result = convert_to_markdown(html)
+    assert result == '<audio src="audio.mp3" controls />\n\n'
+
+
+def test_audio_with_fallback_content() -> None:
+    """Test audio element with fallback content."""
+    html = '<audio src="audio.mp3" controls>Your browser does not support the audio element.</audio>'
+    result = convert_to_markdown(html)
+    expected = '<audio src="audio.mp3" controls>\nYour browser does not support the audio element.\n</audio>\n\n'
+    assert result == expected
+
+
+def test_audio_without_src() -> None:
+    """Test audio element without src attribute."""
+    html = "<audio controls></audio>"
+    result = convert_to_markdown(html)
+    assert result == "<audio controls />\n\n"
+
+
+def test_video_basic() -> None:
+    """Test basic video element conversion."""
+    html = '<video src="video.mp4"></video>'
+    result = convert_to_markdown(html)
+    assert result == '<video src="video.mp4" />\n\n'
+
+
+def test_video_with_dimensions() -> None:
+    """Test video element with width and height."""
+    html = '<video src="video.mp4" width="640" height="480"></video>'
+    result = convert_to_markdown(html)
+    assert result == '<video src="video.mp4" width="640" height="480" />\n\n'
+
+
+def test_video_with_all_attributes() -> None:
+    """Test video element with all common attributes."""
+    html = '<video src="video.mp4" width="640" height="480" poster="poster.jpg" controls autoplay loop muted preload="metadata"></video>'
+    result = convert_to_markdown(html)
+    expected = '<video src="video.mp4" width="640" height="480" poster="poster.jpg" controls autoplay loop muted preload="metadata" />\n\n'
+    assert result == expected
+
+
+def test_video_with_source_element() -> None:
+    """Test video with source child element."""
+    html = """<video controls width="640">
+    <source src="video.mp4" type="video/mp4">
+    <source src="video.webm" type="video/webm">
+</video>"""
+    result = convert_to_markdown(html)
+    assert result == '<video src="video.mp4" width="640" controls />\n\n'
+
+
+def test_video_with_fallback_content() -> None:
+    """Test video element with fallback content."""
+    html = '<video src="video.mp4" controls>Your browser does not support the video element.</video>'
+    result = convert_to_markdown(html)
+    expected = '<video src="video.mp4" controls>\nYour browser does not support the video element.\n</video>\n\n'
+    assert result == expected
+
+
+def test_video_with_track_elements() -> None:
+    """Test video with track elements (subtitles, captions)."""
+    html = """<video src="video.mp4" controls>
+    <track src="subtitles_en.vtt" kind="subtitles" srclang="en" label="English">
+    <track src="subtitles_es.vtt" kind="subtitles" srclang="es" label="Spanish">
+</video>"""
+    result = convert_to_markdown(html)
+    assert result == '<video src="video.mp4" controls />\n\n'
+
+
+def test_iframe_basic() -> None:
+    """Test basic iframe element conversion."""
+    html = '<iframe src="https://example.com"></iframe>'
+    result = convert_to_markdown(html)
+    assert result == '<iframe src="https://example.com"></iframe>\n\n'
+
+
+def test_iframe_with_dimensions() -> None:
+    """Test iframe element with width and height."""
+    html = '<iframe src="https://example.com" width="800" height="600"></iframe>'
+    result = convert_to_markdown(html)
+    assert result == '<iframe src="https://example.com" width="800" height="600"></iframe>\n\n'
+
+
+def test_iframe_with_all_attributes() -> None:
+    """Test iframe element with all common attributes."""
+    html = '<iframe src="https://example.com" width="800" height="600" title="Example Frame" allow="fullscreen" sandbox="allow-scripts" loading="lazy"></iframe>'
+    result = convert_to_markdown(html)
+    expected = '<iframe src="https://example.com" width="800" height="600" title="Example Frame" allow="fullscreen" sandbox="allow-scripts" loading="lazy"></iframe>\n\n'
+    assert result == expected
+
+
+def test_iframe_youtube_embed() -> None:
+    """Test iframe for YouTube embed."""
+    html = '<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>'
+    result = convert_to_markdown(html)
+    expected = '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>\n\n'
+    assert result == expected
+
+
+def test_iframe_with_sandbox_boolean() -> None:
+    """Test iframe with sandbox as boolean attribute."""
+    html = '<iframe src="https://example.com" sandbox></iframe>'
+    result = convert_to_markdown(html)
+    assert result == '<iframe src="https://example.com" sandbox></iframe>\n\n'
+
+
+def test_media_in_paragraphs() -> None:
+    """Test media elements within paragraphs."""
+    html = """<p>Here is an audio file: <audio src="audio.mp3" controls></audio></p>
+<p>Here is a video: <video src="video.mp4" controls></video></p>
+<p>Here is an iframe: <iframe src="https://example.com"></iframe></p>"""
+    result = convert_to_markdown(html)
+    expected = """Here is an audio file: <audio src="audio.mp3" controls />
+
+Here is a video: <video src="video.mp4" controls />
+
+Here is an iframe: <iframe src="https://example.com"></iframe>
+
+"""
+    assert result == expected
+
+
+def test_nested_media_elements() -> None:
+    """Test media elements with nested content."""
+    html = """<article>
+    <h2>Media Gallery</h2>
+    <section>
+        <h3>Audio Section</h3>
+        <audio src="audio1.mp3" controls>
+            <p>Your browser doesn't support HTML5 audio.</p>
+        </audio>
+    </section>
+    <section>
+        <h3>Video Section</h3>
+        <video src="video1.mp4" controls width="640" height="480">
+            <p>Your browser doesn't support HTML5 video.</p>
+        </video>
+    </section>
+</article>"""
+    result = convert_to_markdown(html)
+    expected = """
+Media Gallery
+-------------
+
+### Audio Section
+
+<audio src="audio1.mp3" controls>
+Your browser doesn't support HTML5 audio.
+</audio>
+
+### Video Section
+
+<video src="video1.mp4" width="640" height="480" controls>
+Your browser doesn't support HTML5 video.
+</video>
+
+"""
+    assert result == expected
+
+
+def test_media_inline_mode() -> None:
+    """Test media elements in inline mode."""
+    html = '<audio src="audio.mp3" controls></audio>'
+    result = convert_to_markdown(html, convert_as_inline=True)
+    # In inline mode, trailing newlines are stripped
+    assert result == '<audio src="audio.mp3" controls />'
+
+
+def test_empty_media_attributes() -> None:
+    """Test media elements with empty attributes."""
+    html = '<video src="" width="" height=""></video>'
+    result = convert_to_markdown(html)
+    assert result == "<video />\n\n"
+
+
+def test_media_with_metadata() -> None:
+    """Test media elements work with metadata extraction."""
+    html = """<html>
+<head>
+    <title>Media Page</title>
+    <meta name="description" content="Page with media elements">
+</head>
+<body>
+    <audio src="audio.mp3" controls></audio>
+    <video src="video.mp4" controls></video>
+    <iframe src="https://example.com"></iframe>
+</body>
+</html>"""
+    result = convert_to_markdown(html)
+    expected = """<!--
+meta-description: Page with media elements
+title: Media Page
+-->
+
+<audio src="audio.mp3" controls />
+
+<video src="video.mp4" controls />
+
+<iframe src="https://example.com"></iframe>
+
+"""
+    assert result == expected
+
+
+def test_audio_no_boolean_attributes() -> None:
+    """Test audio element without boolean attributes."""
+    html = '<audio src="audio.mp3" controls="false"></audio>'
+    result = convert_to_markdown(html)
+    # BeautifulSoup treats controls="false" as having controls attribute
+    assert result == '<audio src="audio.mp3" controls />\n\n'
+
+
+def test_video_poster_only() -> None:
+    """Test video element with only poster attribute."""
+    html = '<video poster="poster.jpg"></video>'
+    result = convert_to_markdown(html)
+    assert result == '<video poster="poster.jpg" />\n\n'


### PR DESCRIPTION
## Summary
- Implements Phase 2 of the HTML5 coverage plan
- Adds support for HTML5 media elements: `<audio>`, `<video>`, and `<iframe>`
- These elements are preserved as HTML in the Markdown output to maintain full functionality

## Key Features
### Audio Element Support
- Preserves all audio attributes (src, controls, autoplay, loop, muted, preload)
- Handles `<source>` child elements for multi-format support
- Preserves fallback content for browsers that don't support audio

### Video Element Support  
- Preserves all video attributes (src, width, height, poster, controls, autoplay, loop, muted, preload)
- Handles `<source>` child elements for multi-format support
- Preserves fallback content for browsers that don't support video

### Iframe Element Support
- Preserves all iframe attributes (src, width, height, title, allow, sandbox, loading)
- Special handling for sandbox attribute which can be boolean or space-separated list
- Supports various iframe use cases (YouTube embeds, external content, etc.)

## Additional Improvements
### Newline Normalization
- Added automatic normalization to prevent excessive blank lines (max 1 empty line between content)
- Helps maintain consistent output formatting
- Fixes issues where multiple converters could create too many newlines

### BR Tag Enhancement
- Fixed `<br>` converter to always produce line breaks, even in inline mode
- Ensures line breaks are preserved as intended in the source HTML

## Implementation Details
- Added three new converter functions: `_convert_audio()`, `_convert_video()`, `_convert_iframe()`
- Updated type definitions to include new supported elements
- Empty attribute values are filtered out to keep output clean
- Media elements always produce block-level output with appropriate spacing

## Test plan
[x] Added comprehensive test suite in `tests/media_elements_test.py` with 24 tests
[x] Tests cover all attribute combinations, fallback content, edge cases
[x] All existing tests still pass (234 passing)
[x] Pre-commit hooks pass (mypy, ruff, prettier, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)