### PR TITLE
fix: preserve links in rowspan-affected table cells

### DIFF
--- a/tests/issue_55_test.py
+++ b/tests/issue_55_test.py
@@ -1,0 +1,94 @@
+"""Test for issue #55 - Links in rowspan-affected table cells not converting."""
+
+from html_to_markdown import convert_to_markdown
+
+
+def test_links_in_rowspan_cells() -> None:
+    html = """<table>
+    <tr>
+        <td rowspan="2">Cell A</td>
+        <td><a href="https://example.com">Link B</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://example.com">Link C</a></td>
+    </tr>
+    </table>"""
+
+    result = convert_to_markdown(html)
+
+    assert "[Link B](https://example.com)" in result
+    assert "[Link C](https://example.com)" in result
+    assert "Link C |" not in result or "[Link C]" in result
+
+
+def test_complex_table_with_rowspan_and_links() -> None:
+    html = """<table>
+    <tr>
+        <th>Header 1</th>
+        <th>Header 2</th>
+    </tr>
+    <tr>
+        <td rowspan="2">Spanning Cell</td>
+        <td><a href="https://test.com">First Link</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://test.com">Second Link</a></td>
+    </tr>
+    <tr>
+        <td rowspan="2">Another Span</td>
+        <td><p><a href="https://test.com">Third Link</a></p></td>
+    </tr>
+    <tr>
+        <td><p><a href="https://test.com">Fourth Link</a></p></td>
+    </tr>
+    </table>"""
+
+    result = convert_to_markdown(html)
+
+    assert "[First Link](https://test.com)" in result
+    assert "[Second Link](https://test.com)" in result
+    assert "[Third Link](https://test.com)" in result
+    assert "[Fourth Link](https://test.com)" in result
+
+
+def test_issue_55_exact_case() -> None:
+    html = """<table>
+    <tbody>
+    <tr>
+        <td rowspan="2"><p>EDA</p></td>
+        <td><p><a href="https://www.temp.com" target="_blank">EDB</a></p></td>
+    </tr>
+    <tr>
+        <td><p><a href="https://www.temp.com" target="_blank">EDC</a></p><p><a href="https://www.temp.com" target="_blank">EDD</a></p></td>
+    </tr>
+    </tbody>
+    </table>"""
+
+    result = convert_to_markdown(html)
+
+    assert "[EDB](https://www.temp.com)" in result
+    assert "[EDC](https://www.temp.com)" in result
+    assert "[EDD](https://www.temp.com)" in result
+
+    assert "EDCEDD" not in result or ("[EDC]" in result and "[EDD]" in result)
+
+
+def test_multiple_rowspan_levels() -> None:
+    html = """<table>
+    <tr>
+        <td rowspan="3">A</td>
+        <td><a href="https://example.com">B</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://example.com">C</a></td>
+    </tr>
+    <tr>
+        <td><a href="https://example.com">D</a></td>
+    </tr>
+    </table>"""
+
+    result = convert_to_markdown(html)
+
+    assert "[B](https://example.com)" in result
+    assert "[C](https://example.com)" in result
+    assert "[D](https://example.com)" in result

--- a/tests/issue_59_test.py
+++ b/tests/issue_59_test.py
@@ -8,7 +8,6 @@ def test_nested_list_not_inside_li() -> None:
 
     result = convert_to_markdown(html)
 
-    # The nested list should be indented with 4 spaces
     expected = "* a\n* b\n    + c\n    + d\n"
     assert result == expected
 
@@ -31,7 +30,6 @@ def test_nested_list_not_inside_li_with_multiple_levels() -> None:
 
     assert "* Item 1" in result
     assert "* Item 2" in result
-    # Periods and dashes in text will be escaped
     assert "    + Subitem 2\\.1" in result
     assert "    + Subitem 2\\.2" in result
     assert "        - Sub\\-subitem" in result


### PR DESCRIPTION
## Summary
- Fixes issue #55 where links in table cells with rowspan were being converted to plain text instead of proper Markdown link format
- Root cause was in `_convert_tr` function using `get_text()` to rebuild cell content, losing HTML formatting
- Solution preserves already-converted Markdown content by parsing the text parameter instead of extracting plain text

## Changes
- Modified `_convert_tr` to preserve converted cell formatting in rowspan handling
- Added comprehensive test suite covering various rowspan scenarios with links
- Fixed mypy type annotations and code quality issues

## Test plan
- [x] All existing tests pass
- [x] New test suite covers the reported issue scenarios
- [x] Manual verification shows links now properly convert in rowspan cells
- [x] Pre-commit hooks pass (linting, type checking, etc.)

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)