### PR TITLE
feat: add support for custom navigation classes in HTML preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ The `markdownify` function is an alias for `convert_to_markdown` and provides id
 - `preprocessing_preset` (str, default: `'standard'`): Preprocessing aggressiveness (`'minimal'` for basic cleaning, `'standard'` for balanced, `'aggressive'` for heavy cleaning)
 - `remove_forms` (bool, default: `True`): Remove form elements during preprocessing
 - `remove_navigation` (bool, default: `True`): Remove navigation elements during preprocessing
+- `navigation_classes` (set[str], default: `None`): Custom CSS class names fragments to remove during navigation cleanup. If not provided, uses default navigation classes
 
 ## Contribution
 

--- a/html_to_markdown/processing.py
+++ b/html_to_markdown/processing.py
@@ -476,6 +476,7 @@ def convert_to_markdown(
     preprocessing_preset: Literal["minimal", "standard", "aggressive"] = "standard",
     remove_forms: bool = True,
     remove_navigation: bool = True,
+    navigation_classes: set[str] | None = None,
     strip: str | Iterable[str] | None = None,
     strip_newlines: bool = False,
     strong_em_symbol: Literal["*", "_"] = ASTERISK,
@@ -520,6 +521,7 @@ def convert_to_markdown(
         preprocessing_preset: Preprocessing aggressiveness level.
         remove_forms: Remove form elements during preprocessing.
         remove_navigation: Remove navigation elements during preprocessing.
+        navigation_classes: Set of CSS class fragments to strip with navigation removal.
         strip: HTML tags to strip from output.
         strip_newlines: Remove newlines from HTML before processing.
         strong_em_symbol: Symbol for strong/emphasis ('*' or '_').
@@ -575,6 +577,7 @@ def convert_to_markdown(
             config = create_preprocessor(
                 preset=preprocessing_preset,
                 remove_navigation=remove_navigation,
+                navigation_classes=navigation_classes,
                 remove_forms=remove_forms,
             )
             source = preprocess_fn(source, **config)
@@ -1080,6 +1083,7 @@ def convert_to_markdown_stream(
     preprocessing_preset: Literal["minimal", "standard", "aggressive"] = "standard",
     remove_forms: bool = True,
     remove_navigation: bool = True,
+    navigation_classes: set[str] | None = None,
     strip: str | Iterable[str] | None = None,
     strip_newlines: bool = False,
     strong_em_symbol: Literal["*", "_"] = ASTERISK,
@@ -1098,6 +1102,7 @@ def convert_to_markdown_stream(
         config = create_preprocessor(
             preset=preprocessing_preset,
             remove_navigation=remove_navigation,
+            navigation_classes=navigation_classes,
             remove_forms=remove_forms,
         )
         source = preprocess_fn(source, **config)

--- a/tests/preprocessing_test.py
+++ b/tests/preprocessing_test.py
@@ -33,6 +33,70 @@ def test_remove_navigation() -> None:
     assert "actual content" in cleaned
 
 
+def test_custom_navigation_classes() -> None:
+    html = """
+    <html>
+    <body>
+        <div class="main-links">
+            <ul>
+                <li><a href="#dashboard">Dashboard</a></li>
+                <li><a href="#reports">Reports</a></li>
+            </ul>
+        </div>
+        <main>
+            <h1>Insights</h1>
+            <p>Only the main content should remain.</p>
+        </main>
+    </body>
+    </html>
+    """
+
+    default_cleaned = preprocess_html(html, remove_navigation=True)
+    assert "Dashboard" in default_cleaned
+    assert "Reports" in default_cleaned
+
+    config = create_preprocessor("standard", navigation_classes=["main-links"])
+    custom_cleaned = preprocess_html(html, **config)
+
+    assert "Dashboard" not in custom_cleaned
+    assert "Reports" not in custom_cleaned
+
+    result = convert_to_markdown(
+        html,
+        preprocess_html=True,
+        remove_navigation=True,
+        navigation_classes=["main-links"],
+    )
+
+    assert "Dashboard" not in result
+    assert "Reports" not in result
+    assert "Insights" in result
+    assert "Only the main content" in result
+
+
+def test_default_navigation_classes() -> None:
+    html = """
+    <html>
+    <body>
+        <div class="header">
+            <ul>
+                <li><a href="#dashboard">Dashboard</a></li>
+                <li><a href="#reports">Reports</a></li>
+            </ul>
+        </div>
+        <main>
+            <h1>Insights</h1>
+            <p>Only the main content should remain.</p>
+        </main>
+    </body>
+    </html>
+    """
+
+    default_cleaned = preprocess_html(html, remove_navigation=True)
+    assert "Dashboard" not in default_cleaned
+    assert "Reports" not in default_cleaned
+
+
 def test_remove_forms() -> None:
     html = """
     <html>


### PR DESCRIPTION
- Introduced `navigation_classes` parameter to allow users to specify custom CSS class names for navigation elements to be removed during HTML preprocessing.
- Updated the `preprocess_html` and `_remove_class_based_navigation` functions to accommodate the new parameter.
- Enhanced the `convert_to_markdown` and `convert_to_markdown_stream`  functions to pass the custom navigation classes through the preprocessing pipeline.
- Added tests to verify the functionality of custom navigation class removal and ensure default classes are handled correctly.

### Notes
Didn't update CLI, not sure if it's needed as passing an array of strings might be too too much? But can update if it's required

### CRITICAL
The existing main branch implementation removes only self-closing tags, with the this PR, it's more aggressive and it also removes block tags. I'm not sure if it was a feature or a bug but looking at the classes I assumed it's more like a bug. Can revert back it if needed. 

_Example of the tests currently failing on the main branch_
```
def test_default_navigation_classes() -> None:
    html = """
    <html>
    <body>
        <div class="header">
            <ul>
                <li><a href="#dashboard">Dashboard</a></li>
                <li><a href="#reports">Reports</a></li>
            </ul>
        </div>
        <main>
            <h1>Insights</h1>
            <p>Only the main content should remain.</p>
        </main>
    </body>
    </html>
    """

    default_cleaned = preprocess_html(html, remove_navigation=True)
    assert "Dashboard" not in default_cleaned
    assert "Reports" not in default_cleaned
```
