### PR TITLE
fix: resolve ancestor caching issue causing escaping inside code/pre blocks

### DIFF
--- a/html_to_markdown/processing.py
+++ b/html_to_markdown/processing.py
@@ -314,11 +314,12 @@ def _process_text(
             if len(ancestor_names) > 10:
                 break
 
-    in_pre = bool(ancestor_names.intersection({"pre"}))
+    in_pre = bool(ancestor_names.intersection({"pre"})) or parent_name == "pre"
 
     text = whitespace_handler.process_text_whitespace(text, el, in_pre=in_pre)
 
-    if not ancestor_names.intersection({"pre", "code", "kbd", "samp"}):
+    code_like_tags = {"pre", "code", "kbd", "samp"}
+    if not (ancestor_names.intersection(code_like_tags) or parent_name in code_like_tags):
         text = escape(
             text=text,
             escape_misc=escape_misc,
@@ -617,7 +618,6 @@ def convert_to_markdown(
                         first_child.replace_with(new_text)
                         needs_leading_space_fix = False
 
-            # Fix html5lib whitespace handling to match other parsers
             if parser == "html5lib":
                 body = source.find("body")
                 if body and isinstance(body, Tag):
@@ -632,7 +632,6 @@ def convert_to_markdown(
                         first_child = children[0]
                         original_text = str(first_child)
 
-                        # Preserve leading whitespace from original if html5lib stripped it
                         leading_ws = ""
                         for char in original_source:
                             if char in " \t\n\r":
@@ -640,7 +639,6 @@ def convert_to_markdown(
                             else:
                                 break
 
-                        # Create normalized text: restore leading whitespace only
                         normalized_text = original_text
                         if leading_ws and not normalized_text.startswith(leading_ws):
                             normalized_text = leading_ws + normalized_text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=78.1" ]
 
 [project]
 name = "html-to-markdown"
-version = "1.14.0"
+version = "1.14.1"
 description = "A modern, type-safe Python library for converting HTML to Markdown with comprehensive tag support and customizable options"
 readme = "README.md"
 keywords = [
@@ -61,8 +61,10 @@ dev = [
   "beautifulsoup4[html5lib]>=4.13.5",
   "beautifulsoup4[lxml]>=4.13.5",
   "covdefaults>=2.3",
+  "memray>=1.18",
   "mypy>=1.18.2",
   "pre-commit>=4.3",
+  "psutil>=7.1",
   "pytest>=8.4.2",
   "pytest-benchmark>=5.1",
   "pytest-cov>=7",

--- a/tests/benchmark_memory_test.py
+++ b/tests/benchmark_memory_test.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     from collections.abc import Generator
     from pathlib import Path
 
-import pytest
 
 from html_to_markdown import convert_to_markdown, convert_to_markdown_stream
 
@@ -18,19 +17,8 @@ try:
 except ImportError:
     from tests.performance_test import generate_complex_html
 
-try:
-    import memray
-
-    MEMRAY_AVAILABLE = True
-except ImportError:
-    MEMRAY_AVAILABLE = False
-
-try:
-    import psutil
-
-    PSUTIL_AVAILABLE = True
-except ImportError:
-    PSUTIL_AVAILABLE = False
+import memray
+import psutil
 
 
 @contextmanager
@@ -41,10 +29,8 @@ def memory_snapshot() -> Generator[dict[str, Any], None, None]:
     snapshot_before = tracemalloc.take_snapshot()
     initial_stats = snapshot_before.statistics("lineno")
 
-    process_info = {}
-    if PSUTIL_AVAILABLE:
-        process = psutil.Process()
-        process_info["rss_before"] = process.memory_info().rss
+    process = psutil.Process()
+    process_info = {"rss_before": process.memory_info().rss}
 
     memory_data = {
         "tracemalloc_before": initial_stats,
@@ -61,10 +47,9 @@ def memory_snapshot() -> Generator[dict[str, Any], None, None]:
         snapshot_after = tracemalloc.take_snapshot()
         final_stats = snapshot_after.statistics("lineno")
 
-        if PSUTIL_AVAILABLE:
-            process = psutil.Process()
-            memory_data["process_after"] = {"rss_after": process.memory_info().rss}
-            memory_data["peak_memory"] = process.memory_info().rss
+        process = psutil.Process()
+        memory_data["process_after"] = {"rss_after": process.memory_info().rss}
+        memory_data["peak_memory"] = process.memory_info().rss
 
         memory_data["tracemalloc_after"] = final_stats
 
@@ -86,12 +71,11 @@ class TestMemoryProfiling:
 
         assert len(result) > 0
 
-        if PSUTIL_AVAILABLE and memory_data["process_after"]:
-            memory_used_mb = (
-                (memory_data["process_after"]["rss_after"] - memory_data["process_before"]["rss_before"]) / 1024 / 1024
-            )
+        memory_used_mb = (
+            (memory_data["process_after"]["rss_after"] - memory_data["process_before"]["rss_before"]) / 1024 / 1024
+        )
 
-            assert memory_used_mb < 50, f"Small document used {memory_used_mb:.2f}MB"
+        assert memory_used_mb < 50, f"Small document used {memory_used_mb:.2f}MB"
 
     def test_memory_baseline_large(self) -> None:
         html = generate_complex_html(size_factor=100)
@@ -101,12 +85,11 @@ class TestMemoryProfiling:
 
         assert len(result) > 0
 
-        if PSUTIL_AVAILABLE and memory_data["process_after"]:
-            memory_used_mb = (
-                (memory_data["process_after"]["rss_after"] - memory_data["process_before"]["rss_before"]) / 1024 / 1024
-            )
+        memory_used_mb = (
+            (memory_data["process_after"]["rss_after"] - memory_data["process_before"]["rss_before"]) / 1024 / 1024
+        )
 
-            assert memory_used_mb < 200, f"Large document used {memory_used_mb:.2f}MB"
+        assert memory_used_mb < 200, f"Large document used {memory_used_mb:.2f}MB"
 
     def test_memory_streaming_efficiency(self) -> None:
         html = generate_complex_html(size_factor=100)
@@ -119,22 +102,21 @@ class TestMemoryProfiling:
 
         assert result_regular == result_streaming
 
-        if PSUTIL_AVAILABLE:
-            regular_mb = (
-                (regular_memory["process_after"]["rss_after"] - regular_memory["process_before"]["rss_before"])
-                / 1024
-                / 1024
-            )
+        regular_mb = (
+            (regular_memory["process_after"]["rss_after"] - regular_memory["process_before"]["rss_before"])
+            / 1024
+            / 1024
+        )
 
-            streaming_mb = (
-                (streaming_memory["process_after"]["rss_after"] - streaming_memory["process_before"]["rss_before"])
-                / 1024
-                / 1024
-            )
+        streaming_mb = (
+            (streaming_memory["process_after"]["rss_after"] - streaming_memory["process_before"]["rss_before"])
+            / 1024
+            / 1024
+        )
 
-            assert streaming_mb <= regular_mb * 1.1, (
-                f"Streaming used more memory: {streaming_mb:.2f}MB vs {regular_mb:.2f}MB"
-            )
+        assert streaming_mb <= regular_mb * 1.1, (
+            f"Streaming used more memory: {streaming_mb:.2f}MB vs {regular_mb:.2f}MB"
+        )
 
     def test_memory_leak_detection(self) -> None:
         html = generate_complex_html(size_factor=20)
@@ -142,9 +124,8 @@ class TestMemoryProfiling:
         memory_usage = []
 
         for _i in range(5):
-            if PSUTIL_AVAILABLE:
-                process = psutil.Process()
-                _memory_before = process.memory_info().rss
+            process = psutil.Process()
+            _memory_before = process.memory_info().rss
 
             for _ in range(10):
                 result = convert_to_markdown(html)
@@ -152,11 +133,10 @@ class TestMemoryProfiling:
 
             gc.collect()
 
-            if PSUTIL_AVAILABLE:
-                memory_after = process.memory_info().rss
-                memory_usage.append(memory_after)
+            memory_after = process.memory_info().rss
+            memory_usage.append(memory_after)
 
-        if PSUTIL_AVAILABLE and len(memory_usage) >= 3:
+        if len(memory_usage) >= 3:
             growth_rate = (memory_usage[-1] - memory_usage[0]) / len(memory_usage)
             max_acceptable_growth = 1024 * 1024
 
@@ -165,7 +145,6 @@ class TestMemoryProfiling:
             )
 
 
-@pytest.mark.skipif(not MEMRAY_AVAILABLE, reason="memray not installed")
 class TestMemrayProfiling:
     def test_memray_profile_conversion(self, tmp_path: Path) -> None:
         html = generate_complex_html(size_factor=50)
@@ -203,16 +182,15 @@ def run_memory_analysis() -> None:
         with memory_snapshot() as memory_data:
             result = convert_to_markdown(html)
 
-        if PSUTIL_AVAILABLE and memory_data["process_after"]:
-            memory_used_mb = (
-                (memory_data["process_after"]["rss_after"] - memory_data["process_before"]["rss_before"]) / 1024 / 1024
-            )
+        memory_used_mb = (
+            (memory_data["process_after"]["rss_after"] - memory_data["process_before"]["rss_before"]) / 1024 / 1024
+        )
 
-            efficiency = len(result) / (memory_used_mb * 1024 * 1024) if memory_used_mb > 0 else float("inf")
+        efficiency = len(result) / (memory_used_mb * 1024 * 1024) if memory_used_mb > 0 else float("inf")
 
-            print(f"   Memory used: {memory_used_mb:.2f}MB")
-            print(f"   Output size: {len(result) / 1024:.2f}KB")
-            print(f"   Efficiency: {efficiency:.2f} chars/byte")
+        print(f"   Memory used: {memory_used_mb:.2f}MB")
+        print(f"   Output size: {len(result) / 1024:.2f}KB")
+        print(f"   Efficiency: {efficiency:.2f} chars/byte")
 
         if memory_data["allocations_diff"]:
             print("   Top allocations:")

--- a/tests/benchmark_performance_test.py
+++ b/tests/benchmark_performance_test.py
@@ -13,7 +13,7 @@ import pytest
 from html_to_markdown import convert_to_markdown, convert_to_markdown_stream
 
 if TYPE_CHECKING:
-    from pytest_benchmark.fixture import BenchmarkFixture
+    from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore[import-untyped]
 
 try:
     from .performance_test import generate_complex_html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,11 @@ if HTML5LIB_AVAILABLE:
 @pytest.fixture(params=AVAILABLE_PARSERS)
 def parser(request: pytest.FixtureRequest) -> str:
     """Fixture that runs tests with all available HTML parsers to ensure parser-agnostic behavior."""
-    return request.param
+    return str(request.param)
 
 
 @pytest.fixture
-def convert(parser: str) -> Callable[[str, ...], str]:
+def convert(parser: str) -> Callable[..., str]:
     """Fixture that provides a convert function using the current parser."""
 
     def _convert(html: str, **kwargs: Any) -> str:

--- a/tests/elements_test.py
+++ b/tests/elements_test.py
@@ -14,85 +14,85 @@ if TYPE_CHECKING:
 import pytest
 
 
-def test_cite_element(convert: Callable[[str, ...], str]) -> None:
+def test_cite_element(convert: Callable[..., str]) -> None:
     html = "<cite>Author Name</cite>"
     result = convert(html)
     assert result == "*Author Name*"
 
 
-def test_cite_with_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_cite_with_whitespace(convert: Callable[..., str]) -> None:
     html = "<cite>  Author Name  </cite>"
     result = convert(html)
     assert result == "*Author Name*"
 
 
-def test_cite_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_cite_inline_mode(convert: Callable[..., str]) -> None:
     html = "<cite>Author Name</cite>"
     result = convert(html, convert_as_inline=True)
     assert result == "Author Name"
 
 
-def test_empty_cite(convert: Callable[[str, ...], str]) -> None:
+def test_empty_cite(convert: Callable[..., str]) -> None:
     html = "<cite></cite>"
     result = convert(html)
     assert result == ""
 
 
-def test_cite_with_nested_elements(convert: Callable[[str, ...], str]) -> None:
+def test_cite_with_nested_elements(convert: Callable[..., str]) -> None:
     html = "<cite>Author <strong>Name</strong></cite>"
     result = convert(html)
     assert result == "*Author **Name***"
 
 
-def test_cite_with_link(convert: Callable[[str, ...], str]) -> None:
+def test_cite_with_link(convert: Callable[..., str]) -> None:
     html = '<cite><a href="https://example.com">Author Name</a></cite>'
     result = convert(html)
     assert result == "*[Author Name](https://example.com)*"
 
 
-def test_q_element(convert: Callable[[str, ...], str]) -> None:
+def test_q_element(convert: Callable[..., str]) -> None:
     html = "<q>Short quotation</q>"
     result = convert(html)
     assert result == '"Short quotation"'
 
 
-def test_q_with_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_q_with_whitespace(convert: Callable[..., str]) -> None:
     html = "<q>  Short quotation  </q>"
     result = convert(html)
     assert result == '"Short quotation"'
 
 
-def test_q_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_q_inline_mode(convert: Callable[..., str]) -> None:
     html = "<q>Short quotation</q>"
     result = convert(html, convert_as_inline=True)
     assert result == "Short quotation"
 
 
-def test_empty_q(convert: Callable[[str, ...], str]) -> None:
+def test_empty_q(convert: Callable[..., str]) -> None:
     html = "<q></q>"
     result = convert(html)
     assert result == ""
 
 
-def test_q_with_existing_quotes(convert: Callable[[str, ...], str]) -> None:
+def test_q_with_existing_quotes(convert: Callable[..., str]) -> None:
     html = '<q>He said "Hello" to me</q>'
     result = convert(html)
     assert result == '"He said \\"Hello\\" to me"'
 
 
-def test_q_with_nested_elements(convert: Callable[[str, ...], str]) -> None:
+def test_q_with_nested_elements(convert: Callable[..., str]) -> None:
     html = "<q>A <em>short</em> quotation</q>"
     result = convert(html)
     assert result == '"A *short* quotation"'
 
 
-def test_q_with_code(convert: Callable[[str, ...], str]) -> None:
+def test_q_with_code(convert: Callable[..., str]) -> None:
     html = "<q>The function <code>print()</code> outputs text</q>"
     result = convert(html)
     assert result == '"The function `print()` outputs text"'
 
 
-def test_nested_q_elements(convert: Callable[[str, ...], str]) -> None:
+def test_nested_q_elements(convert: Callable[..., str]) -> None:
     html = "<q>Outer quote <q>inner quote</q> continues</q>"
     result = convert(html)
     assert result == '"Outer quote \\"inner quote\\" continues"'
@@ -122,628 +122,628 @@ def test_nested_q_elements(convert: Callable[[str, ...], str]) -> None:
         ("<dl><dt></dt><dd></dd></dl>", ":\n\n"),
     ],
 )
-def test_definition_list_issues(html: str, expected: str, convert: Callable[[str, ...], str]) -> None:
+def test_definition_list_issues(html: str, expected: str, convert: Callable[..., str]) -> None:
     result = convert(html)
     assert result == expected
 
 
-def test_simple_blockquote(convert: Callable[[str, ...], str]) -> None:
+def test_simple_blockquote(convert: Callable[..., str]) -> None:
     html = "<blockquote>Simple quote</blockquote>"
     result = convert(html)
     assert result == "\n> Simple quote\n\n"
 
 
-def test_blockquote_with_cite(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_with_cite(convert: Callable[..., str]) -> None:
     html = '<blockquote cite="https://example.com">Quote with source</blockquote>'
     result = convert(html)
     expected = "\n> Quote with source\n\n— <https://example.com>\n\n"
     assert result == expected
 
 
-def test_blockquote_with_cite_and_content(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_with_cite_and_content(convert: Callable[..., str]) -> None:
     html = '<blockquote cite="https://shakespeare.com"><p>To be or not to be, that is the question.</p><p>Whether \'tis nobler in the mind to suffer...</p></blockquote>'
     result = convert(html)
     expected = "\n> To be or not to be, that is the question.\n> \n> Whether 'tis nobler in the mind to suffer...\n\n— <https://shakespeare.com>\n\n"
     assert result == expected
 
 
-def test_nested_blockquotes(convert: Callable[[str, ...], str]) -> None:
+def test_nested_blockquotes(convert: Callable[..., str]) -> None:
     html = '<blockquote cite="https://outer.com">Outer quote<blockquote cite="https://inner.com">Inner quote</blockquote>Back to outer</blockquote>'
     result = convert(html)
     expected = "\n> Outer quote\n> \n> \n> > Inner quote\n> \n> — <https://inner.com>\n> \n> Back to outer\n\n— <https://outer.com>\n\n"
     assert result == expected
 
 
-def test_blockquote_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_inline_mode(convert: Callable[..., str]) -> None:
     html = '<blockquote cite="https://example.com">Inline quote</blockquote>'
     result = convert(html, convert_as_inline=True)
     assert result == "Inline quote"
 
 
-def test_empty_blockquote_with_cite(convert: Callable[[str, ...], str]) -> None:
+def test_empty_blockquote_with_cite(convert: Callable[..., str]) -> None:
     html = '<blockquote cite="https://example.com"></blockquote>'
     result = convert(html)
     assert result == ""
 
 
-def test_cite_in_blockquote(convert: Callable[[str, ...], str]) -> None:
+def test_cite_in_blockquote(convert: Callable[..., str]) -> None:
     html = "<blockquote>Quote by <cite>Author Name</cite></blockquote>"
     result = convert(html)
     assert result == "\n> Quote by *Author Name*\n\n"
 
 
-def test_q_in_blockquote(convert: Callable[[str, ...], str]) -> None:
+def test_q_in_blockquote(convert: Callable[..., str]) -> None:
     html = "<blockquote>He said <q>Hello world</q> to everyone.</blockquote>"
     result = convert(html)
     assert result == '\n> He said "Hello world" to everyone.\n\n'
 
 
-def test_blockquote_in_cite(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_in_cite(convert: Callable[..., str]) -> None:
     html = "<cite>Author: <blockquote>Their famous quote</blockquote></cite>"
     result = convert(html)
     assert result == "*Author: \n\n> Their famous quote*"
 
 
-def test_complex_citation_structure(convert: Callable[[str, ...], str]) -> None:
+def test_complex_citation_structure(convert: Callable[..., str]) -> None:
     html = '<article><p>According to <cite><a href="https://example.com">John Doe</a></cite>, the statement <q>Innovation drives progress</q> is fundamental.</p><blockquote cite="https://johndoe.com/quotes"><p>Innovation is not just about technology, it\'s about <em>thinking differently</em>.</p><cite>John Doe, 2023</cite></blockquote></article>'
     result = convert(html)
     expected = 'According to *[John Doe](https://example.com)*, the statement "Innovation drives progress" is fundamental.\n\n> Innovation is not just about technology, it\'s about *thinking differently*.\n> \n> *John Doe, 2023*\n\n— <https://johndoe.com/quotes>\n\n'
     assert result == expected
 
 
-def test_quote_escaping_edge_cases(convert: Callable[[str, ...], str]) -> None:
+def test_quote_escaping_edge_cases(convert: Callable[..., str]) -> None:
     html = '<div><q>Quote with "nested quotes" and \'single quotes\'</q><q>Quote with backslash: \\</q><q>Quote with both \\" and regular quotes</q></div>'
     result = convert(html)
     expected = '"Quote with \\"nested quotes\\" and \'single quotes\'""Quote with backslash: \\\\""Quote with both \\\\\\" and regular quotes"\n\n'
     assert result == expected
 
 
-def test_attributes_preservation(convert: Callable[[str, ...], str]) -> None:
+def test_attributes_preservation(convert: Callable[..., str]) -> None:
     html = '<blockquote cite="https://example.com" class="important" id="quote1" data-author="John">Important quote</blockquote>'
     result = convert(html)
     expected = "\n> Important quote\n\n— <https://example.com>\n\n"
     assert result == expected
 
 
-def test_simple_definition_list(convert: Callable[[str, ...], str]) -> None:
+def test_simple_definition_list(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Term</dt><dd>Definition</dd></dl>"
     result = convert(html)
     expected = "Term\n:   Definition\n\n"
     assert result == expected
 
 
-def test_multiple_terms_and_definitions(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_terms_and_definitions(convert: Callable[..., str]) -> None:
     html = "<dl><dt>First Term</dt><dd>First Definition</dd><dt>Second Term</dt><dd>Second Definition</dd></dl>"
     result = convert(html)
     expected = "First Term\n:   First Definition\n\nSecond Term\n:   Second Definition\n\n"
     assert result == expected
 
 
-def test_term_with_multiple_definitions(convert: Callable[[str, ...], str]) -> None:
+def test_term_with_multiple_definitions(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Term</dt><dd>First definition</dd><dd>Second definition</dd></dl>"
     result = convert(html)
     expected = "Term\n:   First definition\n\n:   Second definition\n\n"
     assert result == expected
 
 
-def test_multiple_terms_single_definition(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_terms_single_definition(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Term 1</dt><dt>Term 2</dt><dd>Shared definition</dd></dl>"
     result = convert(html)
     expected = "Term 1\nTerm 2\n:   Shared definition\n\n"
     assert result == expected
 
 
-def test_definition_with_inline_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_definition_with_inline_formatting(convert: Callable[..., str]) -> None:
     html = "<dl><dt><strong>Bold Term</strong></dt><dd>Definition with <em>italic</em> text</dd></dl>"
     result = convert(html)
     expected = "**Bold Term**\n:   Definition with *italic* text\n\n"
     assert result == expected
 
 
-def test_definition_with_links(convert: Callable[[str, ...], str]) -> None:
+def test_definition_with_links(convert: Callable[..., str]) -> None:
     html = '<dl><dt><a href="https://example.com">Linked Term</a></dt><dd>Definition with <a href="https://test.com">link</a></dd></dl>'
     result = convert(html)
     expected = "[Linked Term](https://example.com)\n:   Definition with [link](https://test.com)\n\n"
     assert result == expected
 
 
-def test_definition_with_code(convert: Callable[[str, ...], str]) -> None:
+def test_definition_with_code(convert: Callable[..., str]) -> None:
     html = "<dl><dt><code>function</code></dt><dd>A block of code with <code>parameters</code></dd></dl>"
     result = convert(html)
     expected = "`function`\n:   A block of code with `parameters`\n\n"
     assert result == expected
 
 
-def test_nested_definition_lists(convert: Callable[[str, ...], str]) -> None:
+def test_nested_definition_lists(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Outer Term</dt><dd>Outer definition<dl><dt>Inner Term</dt><dd>Inner definition</dd></dl></dd></dl>"
     result = convert(html)
     expected = "Outer Term\n:   Outer definition\n\nInner Term\n:   Inner definition\n\n"
     assert result == expected
 
 
-def test_definition_with_paragraphs(convert: Callable[[str, ...], str]) -> None:
+def test_definition_with_paragraphs(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Complex Term</dt><dd><p>First paragraph of definition.</p><p>Second paragraph of definition.</p></dd></dl>"
     result = convert(html)
     expected = "Complex Term\n:   First paragraph of definition.\n\nSecond paragraph of definition.\n\n"
     assert result == expected
 
 
-def test_definition_with_lists(convert: Callable[[str, ...], str]) -> None:
+def test_definition_with_lists(convert: Callable[..., str]) -> None:
     html = "<dl><dt>List Term</dt><dd>Definition with list:<ul><li>Item 1</li><li>Item 2</li></ul></dd></dl>"
     result = convert(html)
     expected = "List Term\n:   Definition with list:\n\n* Item 1\n* Item 2\n\n"
     assert result == expected
 
 
-def test_empty_definition_list(convert: Callable[[str, ...], str]) -> None:
+def test_empty_definition_list(convert: Callable[..., str]) -> None:
     html = "<dl></dl>"
     result = convert(html)
     assert result == ""
 
 
-def test_empty_term(convert: Callable[[str, ...], str]) -> None:
+def test_empty_term(convert: Callable[..., str]) -> None:
     html = "<dl><dt></dt><dd>Definition without term</dd></dl>"
     result = convert(html)
     expected = ":   Definition without term\n\n"
     assert result == expected
 
 
-def test_empty_definition(convert: Callable[[str, ...], str]) -> None:
+def test_empty_definition(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Term without definition</dt><dd></dd></dl>"
     result = convert(html)
     expected = "Term without definition\n:\n\n"
     assert result == expected
 
 
-def test_definition_list_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_definition_list_inline_mode(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Term</dt><dd>Definition</dd></dl>"
     result = convert(html, convert_as_inline=True)
     assert result == "TermDefinition"
 
 
-def test_definition_whitespace_handling(convert: Callable[[str, ...], str]) -> None:
+def test_definition_whitespace_handling(convert: Callable[..., str]) -> None:
     html = "<dl><dt>  Term with spaces  </dt><dd>  Definition with spaces  </dd></dl>"
     result = convert(html)
     expected = "Term with spaces\n:   Definition with spaces\n\n"
     assert result == expected
 
 
-def test_definition_with_blockquote(convert: Callable[[str, ...], str]) -> None:
+def test_definition_with_blockquote(convert: Callable[..., str]) -> None:
     html = "<dl><dt>Quote Term</dt><dd><blockquote>This is a quoted definition.</blockquote></dd></dl>"
     result = convert(html)
     expected = "Quote Term\n:   > This is a quoted definition.\n\n"
     assert result == expected
 
 
-def test_complex_definition_list(convert: Callable[[str, ...], str]) -> None:
+def test_complex_definition_list(convert: Callable[..., str]) -> None:
     html = "<dl><dt><strong>HTML</strong></dt><dd>HyperText Markup Language</dd><dt><em>CSS</em></dt><dt>Cascading Style Sheets</dt><dd>A style sheet language used for describing the presentation of a document written in HTML</dd><dd>Also used with XML documents</dd><dt><code>JavaScript</code></dt><dd>A programming language that conforms to the ECMAScript specification.<ul><li>Dynamic typing</li><li>First-class functions</li></ul></dd></dl>"
     result = convert(html)
     expected = "**HTML**\n:   HyperText Markup Language\n\n*CSS*\nCascading Style Sheets\n:   A style sheet language used for describing the presentation of a document written in HTML\n\n:   Also used with XML documents\n\n`JavaScript`\n:   A programming language that conforms to the ECMAScript specification.\n\n* Dynamic typing\n* First\\-class functions\n\n"
     assert result == expected
 
 
-def test_definition_list_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_definition_list_attributes(convert: Callable[..., str]) -> None:
     html = '<dl class="definitions" id="main-list"><dt title="Term title">Term</dt><dd data-id="1">Definition</dd></dl>'
     result = convert(html)
     expected = "Term\n:   Definition\n\n"
     assert result == expected
 
 
-def test_form_basic(convert: Callable[[str, ...], str]) -> None:
+def test_form_basic(convert: Callable[..., str]) -> None:
     html = "<form><p>Form content</p></form>"
     result = convert(html)
     assert result == "Form content\n\n"
 
 
-def test_form_with_action(convert: Callable[[str, ...], str]) -> None:
+def test_form_with_action(convert: Callable[..., str]) -> None:
     html = '<form action="/submit"><p>Form content</p></form>'
     result = convert(html)
     assert result == "Form content\n\n"
 
 
-def test_form_with_method(convert: Callable[[str, ...], str]) -> None:
+def test_form_with_method(convert: Callable[..., str]) -> None:
     html = '<form method="post"><p>Form content</p></form>'
     result = convert(html)
     assert result == "Form content\n\n"
 
 
-def test_form_with_action_and_method(convert: Callable[[str, ...], str]) -> None:
+def test_form_with_action_and_method(convert: Callable[..., str]) -> None:
     html = '<form action="/submit" method="post"><p>Form content</p></form>'
     result = convert(html)
     assert result == "Form content\n\n"
 
 
-def test_form_empty(convert: Callable[[str, ...], str]) -> None:
+def test_form_empty(convert: Callable[..., str]) -> None:
     html = "<form></form>"
     result = convert(html)
     assert result == ""
 
 
-def test_form_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_form_inline_mode(convert: Callable[..., str]) -> None:
     html = "<form>Form content</form>"
     result = convert(html, convert_as_inline=True)
     assert result == "Form content"
 
 
-def test_fieldset_basic(convert: Callable[[str, ...], str]) -> None:
+def test_fieldset_basic(convert: Callable[..., str]) -> None:
     html = "<fieldset><p>Fieldset content</p></fieldset>"
     result = convert(html)
     assert result == "Fieldset content\n\n"
 
 
-def test_fieldset_with_legend(convert: Callable[[str, ...], str]) -> None:
+def test_fieldset_with_legend(convert: Callable[..., str]) -> None:
     html = "<fieldset><legend>Form Section</legend><p>Content</p></fieldset>"
     result = convert(html)
     assert result == "**Form Section**\n\nContent\n\n"
 
 
-def test_legend_standalone(convert: Callable[[str, ...], str]) -> None:
+def test_legend_standalone(convert: Callable[..., str]) -> None:
     html = "<legend>Legend text</legend>"
     result = convert(html)
     assert result == "**Legend text**\n\n"
 
 
-def test_fieldset_empty(convert: Callable[[str, ...], str]) -> None:
+def test_fieldset_empty(convert: Callable[..., str]) -> None:
     html = "<fieldset></fieldset>"
     result = convert(html)
     assert result == ""
 
 
-def test_legend_empty(convert: Callable[[str, ...], str]) -> None:
+def test_legend_empty(convert: Callable[..., str]) -> None:
     html = "<legend></legend>"
     result = convert(html)
     assert result == ""
 
 
-def test_fieldset_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_fieldset_inline_mode(convert: Callable[..., str]) -> None:
     html = "<fieldset>Inline content</fieldset>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline content"
 
 
-def test_label_basic(convert: Callable[[str, ...], str]) -> None:
+def test_label_basic(convert: Callable[..., str]) -> None:
     html = "<label>Label text</label>"
     result = convert(html)
     assert result == "Label text\n\n"
 
 
-def test_label_with_for(convert: Callable[[str, ...], str]) -> None:
+def test_label_with_for(convert: Callable[..., str]) -> None:
     html = '<label for="username">Username</label>'
     result = convert(html)
     assert result == "Username\n\n"
 
 
-def test_label_with_input(convert: Callable[[str, ...], str]) -> None:
+def test_label_with_input(convert: Callable[..., str]) -> None:
     html = '<label>Username: <input type="text" name="username"></label>'
     result = convert(html)
     assert result == "Username:\n\n"
 
 
-def test_label_empty(convert: Callable[[str, ...], str]) -> None:
+def test_label_empty(convert: Callable[..., str]) -> None:
     html = "<label></label>"
     result = convert(html)
     assert result == ""
 
 
-def test_label_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_label_inline_mode(convert: Callable[..., str]) -> None:
     html = "<label>Inline label</label>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline label"
 
 
-def test_input_text(convert: Callable[[str, ...], str]) -> None:
+def test_input_text(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_password(convert: Callable[[str, ...], str]) -> None:
+def test_input_password(convert: Callable[..., str]) -> None:
     html = '<input type="password" name="password">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_with_value(convert: Callable[[str, ...], str]) -> None:
+def test_input_with_value(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username" value="john">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_with_placeholder(convert: Callable[[str, ...], str]) -> None:
+def test_input_with_placeholder(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username" placeholder="Enter username">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_required(convert: Callable[[str, ...], str]) -> None:
+def test_input_required(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username" required>'
     result = convert(html)
     assert result == ""
 
 
-def test_input_disabled(convert: Callable[[str, ...], str]) -> None:
+def test_input_disabled(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username" disabled>'
     result = convert(html)
     assert result == ""
 
 
-def test_input_readonly(convert: Callable[[str, ...], str]) -> None:
+def test_input_readonly(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username" readonly>'
     result = convert(html)
     assert result == ""
 
 
-def test_input_checkbox_unchecked(convert: Callable[[str, ...], str]) -> None:
+def test_input_checkbox_unchecked(convert: Callable[..., str]) -> None:
     html = '<input type="checkbox" name="agree">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_checkbox_checked(convert: Callable[[str, ...], str]) -> None:
+def test_input_checkbox_checked(convert: Callable[..., str]) -> None:
     html = '<input type="checkbox" name="agree" checked>'
     result = convert(html)
     assert result == ""
 
 
-def test_input_radio(convert: Callable[[str, ...], str]) -> None:
+def test_input_radio(convert: Callable[..., str]) -> None:
     html = '<input type="radio" name="gender" value="male">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_submit(convert: Callable[[str, ...], str]) -> None:
+def test_input_submit(convert: Callable[..., str]) -> None:
     html = '<input type="submit" value="Submit">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_file(convert: Callable[[str, ...], str]) -> None:
+def test_input_file(convert: Callable[..., str]) -> None:
     html = '<input type="file" name="upload" accept=".jpg,.png">'
     result = convert(html)
     assert result == ""
 
 
-def test_input_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_input_inline_mode(convert: Callable[..., str]) -> None:
     html = '<input type="text" name="username">'
     result = convert(html, convert_as_inline=True)
     assert result == ""
 
 
-def test_textarea_basic(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_basic(convert: Callable[..., str]) -> None:
     html = "<textarea>Default text</textarea>"
     result = convert(html)
     assert result == "Default text\n\n"
 
 
-def test_textarea_with_name(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_with_name(convert: Callable[..., str]) -> None:
     html = '<textarea name="comment">Comment text</textarea>'
     result = convert(html)
     assert result == "Comment text\n\n"
 
 
-def test_textarea_with_placeholder(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_with_placeholder(convert: Callable[..., str]) -> None:
     html = '<textarea placeholder="Enter your comment">Default text</textarea>'
     result = convert(html)
     assert result == "Default text\n\n"
 
 
-def test_textarea_with_rows_cols(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_with_rows_cols(convert: Callable[..., str]) -> None:
     html = '<textarea rows="5" cols="30">Text</textarea>'
     result = convert(html)
     assert result == "Text\n\n"
 
 
-def test_textarea_required(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_required(convert: Callable[..., str]) -> None:
     html = "<textarea required>Required text</textarea>"
     result = convert(html)
     assert result == "Required text\n\n"
 
 
-def test_textarea_empty(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_empty(convert: Callable[..., str]) -> None:
     html = "<textarea></textarea>"
     result = convert(html)
     assert result == ""
 
 
-def test_textarea_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_textarea_inline_mode(convert: Callable[..., str]) -> None:
     html = "<textarea>Inline text</textarea>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline text"
 
 
-def test_select_basic(convert: Callable[[str, ...], str]) -> None:
+def test_select_basic(convert: Callable[..., str]) -> None:
     html = "<select><option>Option 1</option><option>Option 2</option></select>"
     result = convert(html)
     assert result == "Option 1\nOption 2\n\n"
 
 
-def test_select_with_name(convert: Callable[[str, ...], str]) -> None:
+def test_select_with_name(convert: Callable[..., str]) -> None:
     html = '<select name="country"><option>USA</option><option>Canada</option></select>'
     result = convert(html)
     assert result == "USA\nCanada\n\n"
 
 
-def test_select_multiple(convert: Callable[[str, ...], str]) -> None:
+def test_select_multiple(convert: Callable[..., str]) -> None:
     html = "<select multiple><option>Option 1</option><option>Option 2</option></select>"
     result = convert(html)
     assert result == "Option 1\nOption 2\n\n"
 
 
-def test_option_with_value(convert: Callable[[str, ...], str]) -> None:
+def test_option_with_value(convert: Callable[..., str]) -> None:
     html = '<select><option value="us">United States</option><option value="ca">Canada</option></select>'
     result = convert(html)
     assert result == "United States\nCanada\n\n"
 
 
-def test_option_selected(convert: Callable[[str, ...], str]) -> None:
+def test_option_selected(convert: Callable[..., str]) -> None:
     html = "<select><option>Option 1</option><option selected>Option 2</option></select>"
     result = convert(html)
     assert result == "Option 1\n* Option 2\n\n"
 
 
-def test_optgroup(convert: Callable[[str, ...], str]) -> None:
+def test_optgroup(convert: Callable[..., str]) -> None:
     html = '<select><optgroup label="Group 1"><option>Option 1</option><option>Option 2</option></optgroup></select>'
     result = convert(html)
     assert result == "**Group 1**\nOption 1\nOption 2\n\n"
 
 
-def test_select_empty(convert: Callable[[str, ...], str]) -> None:
+def test_select_empty(convert: Callable[..., str]) -> None:
     html = "<select></select>"
     result = convert(html)
     assert result == ""
 
 
-def test_option_empty(convert: Callable[[str, ...], str]) -> None:
+def test_option_empty(convert: Callable[..., str]) -> None:
     html = "<select><option></option></select>"
     result = convert(html)
     assert result == ""
 
 
-def test_select_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_select_inline_mode(convert: Callable[..., str]) -> None:
     html = "<select><option>Option</option></select>"
     result = convert(html, convert_as_inline=True)
     assert result == "Option"
 
 
-def test_button_basic(convert: Callable[[str, ...], str]) -> None:
+def test_button_basic(convert: Callable[..., str]) -> None:
     html = "<button>Click me</button>"
     result = convert(html)
     assert result == "Click me\n\n"
 
 
-def test_button_with_type(convert: Callable[[str, ...], str]) -> None:
+def test_button_with_type(convert: Callable[..., str]) -> None:
     html = '<button type="submit">Submit</button>'
     result = convert(html)
     assert result == "Submit\n\n"
 
 
-def test_button_disabled(convert: Callable[[str, ...], str]) -> None:
+def test_button_disabled(convert: Callable[..., str]) -> None:
     html = "<button disabled>Disabled</button>"
     result = convert(html)
     assert result == "Disabled\n\n"
 
 
-def test_button_with_name_value(convert: Callable[[str, ...], str]) -> None:
+def test_button_with_name_value(convert: Callable[..., str]) -> None:
     html = '<button name="action" value="delete">Delete</button>'
     result = convert(html)
     assert result == "Delete\n\n"
 
 
-def test_button_empty(convert: Callable[[str, ...], str]) -> None:
+def test_button_empty(convert: Callable[..., str]) -> None:
     html = "<button></button>"
     result = convert(html)
     assert result == ""
 
 
-def test_button_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_button_inline_mode(convert: Callable[..., str]) -> None:
     html = "<button>Inline button</button>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline button"
 
 
-def test_progress_basic(convert: Callable[[str, ...], str]) -> None:
+def test_progress_basic(convert: Callable[..., str]) -> None:
     html = "<progress>50%</progress>"
     result = convert(html)
     assert result == "50%\n\n"
 
 
-def test_progress_with_value_max(convert: Callable[[str, ...], str]) -> None:
+def test_progress_with_value_max(convert: Callable[..., str]) -> None:
     html = '<progress value="50" max="100">50%</progress>'
     result = convert(html)
     assert result == "50%\n\n"
 
 
-def test_meter_basic(convert: Callable[[str, ...], str]) -> None:
+def test_meter_basic(convert: Callable[..., str]) -> None:
     html = "<meter>6 out of 10</meter>"
     result = convert(html)
     assert result == "6 out of 10\n\n"
 
 
-def test_meter_with_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_meter_with_attributes(convert: Callable[..., str]) -> None:
     html = '<meter value="6" min="0" max="10" low="2" high="8" optimum="5">6 out of 10</meter>'
     result = convert(html)
     assert result == "6 out of 10\n\n"
 
 
-def test_progress_empty(convert: Callable[[str, ...], str]) -> None:
+def test_progress_empty(convert: Callable[..., str]) -> None:
     html = "<progress></progress>"
     result = convert(html)
     assert result == ""
 
 
-def test_meter_empty(convert: Callable[[str, ...], str]) -> None:
+def test_meter_empty(convert: Callable[..., str]) -> None:
     html = "<meter></meter>"
     result = convert(html)
     assert result == ""
 
 
-def test_progress_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_progress_inline_mode(convert: Callable[..., str]) -> None:
     html = "<progress>50%</progress>"
     result = convert(html, convert_as_inline=True)
     assert result == "50%"
 
 
-def test_meter_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_meter_inline_mode(convert: Callable[..., str]) -> None:
     html = "<meter>6/10</meter>"
     result = convert(html, convert_as_inline=True)
     assert result == "6/10"
 
 
-def test_output_basic(convert: Callable[[str, ...], str]) -> None:
+def test_output_basic(convert: Callable[..., str]) -> None:
     html = "<output>Result: 42</output>"
     result = convert(html)
     assert result == "Result: 42\n\n"
 
 
-def test_output_with_for(convert: Callable[[str, ...], str]) -> None:
+def test_output_with_for(convert: Callable[..., str]) -> None:
     html = '<output for="input1 input2">Sum: 15</output>'
     result = convert(html)
     assert result == "Sum: 15\n\n"
 
 
-def test_output_with_name(convert: Callable[[str, ...], str]) -> None:
+def test_output_with_name(convert: Callable[..., str]) -> None:
     html = '<output name="result">42</output>'
     result = convert(html)
     assert result == "42\n\n"
 
 
-def test_datalist_basic(convert: Callable[[str, ...], str]) -> None:
+def test_datalist_basic(convert: Callable[..., str]) -> None:
     html = "<datalist><option>Option 1</option><option>Option 2</option></datalist>"
     result = convert(html)
     assert result == "Option 1\nOption 2\n\n"
 
 
-def test_datalist_with_id(convert: Callable[[str, ...], str]) -> None:
+def test_datalist_with_id(convert: Callable[..., str]) -> None:
     html = '<datalist id="browsers"><option>Chrome</option><option>Firefox</option></datalist>'
     result = convert(html)
     assert result == "Chrome\nFirefox\n\n"
 
 
-def test_output_empty(convert: Callable[[str, ...], str]) -> None:
+def test_output_empty(convert: Callable[..., str]) -> None:
     html = "<output></output>"
     result = convert(html)
     assert result == ""
 
 
-def test_datalist_empty(convert: Callable[[str, ...], str]) -> None:
+def test_datalist_empty(convert: Callable[..., str]) -> None:
     html = "<datalist></datalist>"
     result = convert(html)
     assert result == ""
 
 
-def test_output_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_output_inline_mode(convert: Callable[..., str]) -> None:
     html = "<output>Result</output>"
     result = convert(html, convert_as_inline=True)
     assert result == "Result"
 
 
-def test_datalist_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_datalist_inline_mode(convert: Callable[..., str]) -> None:
     html = "<datalist><option>Option</option></datalist>"
     result = convert(html, convert_as_inline=True)
     assert result == "Option"
 
 
-def test_complete_form_example(convert: Callable[[str, ...], str]) -> None:
+def test_complete_form_example(convert: Callable[..., str]) -> None:
     html = """<form action="/submit" method="post">
         <fieldset>
             <legend>Personal Information</legend>
@@ -788,7 +788,7 @@ Submit
     assert result == expected
 
 
-def test_form_with_progress_and_meter(convert: Callable[[str, ...], str]) -> None:
+def test_form_with_progress_and_meter(convert: Callable[..., str]) -> None:
     html = """<form>
         <label>Upload Progress:</label>
         <progress value="75" max="100">75%</progress>
@@ -811,169 +811,169 @@ Current rating: 4/5
     assert result == expected
 
 
-def test_form_with_inputs_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_form_with_inputs_inline_mode(convert: Callable[..., str]) -> None:
     html = '<form><label>Name:</label> <input type="text" name="name"> <button>Submit</button></form>'
     result = convert(html, convert_as_inline=True)
     assert result == "Name:  Submit"
 
 
-def test_article_element(convert: Callable[[str, ...], str]) -> None:
+def test_article_element(convert: Callable[..., str]) -> None:
     html = "<article>This is an article</article>"
     result = convert(html)
     assert result == "This is an article\n\n"
 
 
-def test_section_element(convert: Callable[[str, ...], str]) -> None:
+def test_section_element(convert: Callable[..., str]) -> None:
     html = "<section>This is a section</section>"
     result = convert(html)
     assert result == "This is a section\n\n"
 
 
-def test_nav_element(convert: Callable[[str, ...], str]) -> None:
+def test_nav_element(convert: Callable[..., str]) -> None:
     html = "<nav>This is navigation</nav>"
     result = convert(html)
     assert result == "This is navigation\n\n"
 
 
-def test_aside_element(convert: Callable[[str, ...], str]) -> None:
+def test_aside_element(convert: Callable[..., str]) -> None:
     html = "<aside>This is an aside</aside>"
     result = convert(html)
     assert result == "This is an aside\n\n"
 
 
-def test_header_element(convert: Callable[[str, ...], str]) -> None:
+def test_header_element(convert: Callable[..., str]) -> None:
     html = "<header>This is a header</header>"
     result = convert(html)
     assert result == "This is a header\n\n"
 
 
-def test_footer_element(convert: Callable[[str, ...], str]) -> None:
+def test_footer_element(convert: Callable[..., str]) -> None:
     html = "<footer>This is a footer</footer>"
     result = convert(html)
     assert result == "This is a footer\n\n"
 
 
-def test_main_element(convert: Callable[[str, ...], str]) -> None:
+def test_main_element(convert: Callable[..., str]) -> None:
     html = "<main>This is main content</main>"
     result = convert(html)
     assert result == "This is main content\n\n"
 
 
-def test_article_with_sections(convert: Callable[[str, ...], str]) -> None:
+def test_article_with_sections(convert: Callable[..., str]) -> None:
     html = "<article><header>Article Header</header><section><h2>Section Title</h2><p>Section content</p></section><footer>Article Footer</footer></article>"
     result = convert(html, heading_style="atx")
     expected = "Article Header\n\n## Section Title\n\nSection content\n\nArticle Footer\n\n"
     assert result == expected
 
 
-def test_semantic_elements_with_other_content(convert: Callable[[str, ...], str]) -> None:
+def test_semantic_elements_with_other_content(convert: Callable[..., str]) -> None:
     html = '<nav><ul><li><a href="#home">Home</a></li><li><a href="#about">About</a></li></ul></nav><main><article><h1>Article Title</h1><p>Article content</p></article></main>'
     result = convert(html, heading_style="atx")
     expected = "* [Home](#home)\n* [About](#about)\n\n# Article Title\n\nArticle content\n\n"
     assert result == expected
 
 
-def test_empty_article_element(convert: Callable[[str, ...], str]) -> None:
+def test_empty_article_element(convert: Callable[..., str]) -> None:
     html = "<article></article>"
     result = convert(html)
     assert result == ""
 
 
-def test_article_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_article_inline_mode(convert: Callable[..., str]) -> None:
     html = "<article>This is inline content</article>"
     result = convert(html, convert_as_inline=True)
     assert result == "This is inline content"
 
 
-def test_semantic_elements_with_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_semantic_elements_with_whitespace(convert: Callable[..., str]) -> None:
     html = "<section>  \n  Content with whitespace  \n  </section>"
     result = convert(html)
     assert result == " Content with whitespace \n\n"
 
 
-def test_details_element(convert: Callable[[str, ...], str]) -> None:
+def test_details_element(convert: Callable[..., str]) -> None:
     html = "<details>This is details content</details>"
     result = convert(html)
     assert result == "This is details content\n\n"
 
 
-def test_summary_element(convert: Callable[[str, ...], str]) -> None:
+def test_summary_element(convert: Callable[..., str]) -> None:
     html = "<summary>Summary text</summary>"
     result = convert(html)
     assert result == "**Summary text**\n\n"
 
 
-def test_details_with_summary(convert: Callable[[str, ...], str]) -> None:
+def test_details_with_summary(convert: Callable[..., str]) -> None:
     html = "<details><summary>Click to expand</summary><p>Hidden content here</p></details>"
     result = convert(html)
     expected = "**Click to expand**\n\nHidden content here\n\n"
     assert result == expected
 
 
-def test_nested_details(convert: Callable[[str, ...], str]) -> None:
+def test_nested_details(convert: Callable[..., str]) -> None:
     html = "<details><summary>Level 1</summary><details><summary>Level 2</summary><p>Nested content</p></details></details>"
     result = convert(html)
     expected = "**Level 1**\n\n**Level 2**\n\nNested content\n\n"
     assert result == expected
 
 
-def test_details_with_complex_content(convert: Callable[[str, ...], str]) -> None:
+def test_details_with_complex_content(convert: Callable[..., str]) -> None:
     html = '<details><summary>Code Example</summary><pre><code>def hello():\n    print("Hello, World!")</code></pre><p>This is a Python function.</p></details>'
     result = convert(html)
     expected = '**Code Example**\n\n```\ndef hello():\n    print("Hello, World!")\n```\nThis is a Python function.\n\n'
     assert result == expected
 
 
-def test_empty_details(convert: Callable[[str, ...], str]) -> None:
+def test_empty_details(convert: Callable[..., str]) -> None:
     html = "<details></details>"
     result = convert(html)
     assert result == ""
 
 
-def test_empty_summary(convert: Callable[[str, ...], str]) -> None:
+def test_empty_summary(convert: Callable[..., str]) -> None:
     html = "<summary></summary>"
     result = convert(html)
     assert result == ""
 
 
-def test_details_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_details_inline_mode(convert: Callable[..., str]) -> None:
     html = "<details>Inline details</details>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline details"
 
 
-def test_summary_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_summary_inline_mode(convert: Callable[..., str]) -> None:
     html = "<summary>Inline summary</summary>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline summary"
 
 
-def test_details_with_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_details_with_attributes(convert: Callable[..., str]) -> None:
     html = "<details open><summary>Always open</summary><p>Content</p></details>"
     result = convert(html)
     expected = "**Always open**\n\nContent\n\n"
     assert result == expected
 
 
-def test_audio_basic(convert: Callable[[str, ...], str]) -> None:
+def test_audio_basic(convert: Callable[..., str]) -> None:
     html = '<audio src="audio.mp3"></audio>'
     result = convert(html)
     assert result == "[audio.mp3](audio.mp3)\n\n"
 
 
-def test_audio_with_controls(convert: Callable[[str, ...], str]) -> None:
+def test_audio_with_controls(convert: Callable[..., str]) -> None:
     html = '<audio src="audio.mp3" controls></audio>'
     result = convert(html)
     assert result == "[audio.mp3](audio.mp3)\n\n"
 
 
-def test_audio_with_all_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_audio_with_all_attributes(convert: Callable[..., str]) -> None:
     html = '<audio src="audio.mp3" controls autoplay loop muted preload="auto"></audio>'
     result = convert(html)
     assert result == "[audio.mp3](audio.mp3)\n\n"
 
 
-def test_audio_with_source_element(convert: Callable[[str, ...], str]) -> None:
+def test_audio_with_source_element(convert: Callable[..., str]) -> None:
     html = """<audio controls>
     <source src="audio.mp3" type="audio/mpeg">
     <source src="audio.ogg" type="audio/ogg">
@@ -982,38 +982,38 @@ def test_audio_with_source_element(convert: Callable[[str, ...], str]) -> None:
     assert result == "[audio.mp3](audio.mp3)\n\n"
 
 
-def test_audio_with_fallback_content(convert: Callable[[str, ...], str]) -> None:
+def test_audio_with_fallback_content(convert: Callable[..., str]) -> None:
     html = '<audio src="audio.mp3" controls>Your browser does not support the audio element.</audio>'
     result = convert(html)
     expected = "[audio.mp3](audio.mp3)\n\nYour browser does not support the audio element.\n\n"
     assert result == expected
 
 
-def test_audio_without_src(convert: Callable[[str, ...], str]) -> None:
+def test_audio_without_src(convert: Callable[..., str]) -> None:
     html = "<audio controls></audio>"
     result = convert(html)
     assert result == ""
 
 
-def test_video_basic(convert: Callable[[str, ...], str]) -> None:
+def test_video_basic(convert: Callable[..., str]) -> None:
     html = '<video src="video.mp4"></video>'
     result = convert(html)
     assert result == "[video.mp4](video.mp4)\n\n"
 
 
-def test_video_with_dimensions(convert: Callable[[str, ...], str]) -> None:
+def test_video_with_dimensions(convert: Callable[..., str]) -> None:
     html = '<video src="video.mp4" width="640" height="480"></video>'
     result = convert(html)
     assert result == "[video.mp4](video.mp4)\n\n"
 
 
-def test_video_with_all_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_video_with_all_attributes(convert: Callable[..., str]) -> None:
     html = '<video src="video.mp4" width="640" height="480" poster="poster.jpg" controls autoplay loop muted preload="metadata"></video>'
     result = convert(html)
     assert result == "[video.mp4](video.mp4)\n\n"
 
 
-def test_video_with_source_element(convert: Callable[[str, ...], str]) -> None:
+def test_video_with_source_element(convert: Callable[..., str]) -> None:
     html = """<video controls width="640">
     <source src="video.mp4" type="video/mp4">
     <source src="video.webm" type="video/webm">
@@ -1022,14 +1022,14 @@ def test_video_with_source_element(convert: Callable[[str, ...], str]) -> None:
     assert result == "[video.mp4](video.mp4)\n\n"
 
 
-def test_video_with_fallback_content(convert: Callable[[str, ...], str]) -> None:
+def test_video_with_fallback_content(convert: Callable[..., str]) -> None:
     html = '<video src="video.mp4" controls>Your browser does not support the video element.</video>'
     result = convert(html)
     expected = "[video.mp4](video.mp4)\n\nYour browser does not support the video element.\n\n"
     assert result == expected
 
 
-def test_video_with_track_elements(convert: Callable[[str, ...], str]) -> None:
+def test_video_with_track_elements(convert: Callable[..., str]) -> None:
     html = """<video src="video.mp4" controls>
     <track src="subtitles_en.vtt" kind="subtitles" srclang="en" label="English">
     <track src="subtitles_es.vtt" kind="subtitles" srclang="es" label="Spanish">
@@ -1038,43 +1038,43 @@ def test_video_with_track_elements(convert: Callable[[str, ...], str]) -> None:
     assert result == "[video.mp4](video.mp4)\n\n"
 
 
-def test_iframe_basic(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_basic(convert: Callable[..., str]) -> None:
     html = '<iframe src="https://example.com"></iframe>'
     result = convert(html)
     assert result == "[https://example.com](https://example.com)\n\n"
 
 
-def test_iframe_with_dimensions(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_with_dimensions(convert: Callable[..., str]) -> None:
     html = '<iframe src="https://example.com" width="800" height="600"></iframe>'
     result = convert(html)
     assert result == "[https://example.com](https://example.com)\n\n"
 
 
-def test_iframe_with_all_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_with_all_attributes(convert: Callable[..., str]) -> None:
     html = '<iframe src="https://example.com" width="800" height="600" title="Example Frame" allow="fullscreen" sandbox="allow-scripts" loading="lazy"></iframe>'
     result = convert(html)
     assert result == "[https://example.com](https://example.com)\n\n"
 
 
-def test_iframe_youtube_embed(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_youtube_embed(convert: Callable[..., str]) -> None:
     html = '<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>'
     result = convert(html)
     assert result == "[https://www.youtube.com/embed/dQw4w9WgXcQ](https://www.youtube.com/embed/dQw4w9WgXcQ)\n\n"
 
 
-def test_iframe_with_sandbox_boolean(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_with_sandbox_boolean(convert: Callable[..., str]) -> None:
     html = '<iframe src="https://example.com" sandbox></iframe>'
     result = convert(html)
     assert result == "[https://example.com](https://example.com)\n\n"
 
 
-def test_blockquote_with_single_newline_end(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_with_single_newline_end(convert: Callable[..., str]) -> None:
     html = "<blockquote>Test content\n</blockquote>"
     result = convert(html)
     assert result == "\n> Test content\n\n"
 
 
-def test_list_with_empty_lines_multiline_content(convert: Callable[[str, ...], str]) -> None:
+def test_list_with_empty_lines_multiline_content(convert: Callable[..., str]) -> None:
     html = """<ul>
     <li><p>First paragraph</p>
 
@@ -1084,7 +1084,7 @@ def test_list_with_empty_lines_multiline_content(convert: Callable[[str, ...], s
     assert "First paragraph\n\n    Second paragraph" in result
 
 
-def test_list_with_empty_lines(convert: Callable[[str, ...], str]) -> None:
+def test_list_with_empty_lines(convert: Callable[..., str]) -> None:
     html = """<ul>
     <li>
         First item
@@ -1097,7 +1097,7 @@ def test_list_with_empty_lines(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_media_in_paragraphs(convert: Callable[[str, ...], str]) -> None:
+def test_media_in_paragraphs(convert: Callable[..., str]) -> None:
     html = """<p>Here is an audio file: <audio src="audio.mp3" controls></audio></p>
 <p>Here is a video: <video src="video.mp4" controls></video></p>
 <p>Here is an iframe: <iframe src="https://example.com"></iframe></p>"""
@@ -1112,7 +1112,7 @@ Here is an iframe: [https://example.com](https://example.com)
     assert result == expected
 
 
-def test_nested_media_elements(convert: Callable[[str, ...], str]) -> None:
+def test_nested_media_elements(convert: Callable[..., str]) -> None:
     html = """<article>
     <h2>Media Gallery</h2>
     <section>
@@ -1148,19 +1148,19 @@ Your browser doesn't support HTML5 video.
     assert result == expected
 
 
-def test_media_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_media_inline_mode(convert: Callable[..., str]) -> None:
     html = '<audio src="audio.mp3" controls></audio>'
     result = convert(html, convert_as_inline=True)
     assert result == "[audio.mp3](audio.mp3)"
 
 
-def test_empty_media_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_empty_media_attributes(convert: Callable[..., str]) -> None:
     html = '<video src="" width="" height=""></video>'
     result = convert(html)
     assert result == ""
 
 
-def test_media_with_metadata(convert: Callable[[str, ...], str]) -> None:
+def test_media_with_metadata(convert: Callable[..., str]) -> None:
     html = """<html>
 <head>
     <title>Media Page</title>
@@ -1188,235 +1188,235 @@ title: Media Page
     assert result == expected
 
 
-def test_audio_no_boolean_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_audio_no_boolean_attributes(convert: Callable[..., str]) -> None:
     html = '<audio src="audio.mp3" controls="false"></audio>'
     result = convert(html)
     assert result == "[audio.mp3](audio.mp3)\n\n"
 
 
-def test_video_poster_only(convert: Callable[[str, ...], str]) -> None:
+def test_video_poster_only(convert: Callable[..., str]) -> None:
     html = '<video poster="poster.jpg"></video>'
     result = convert(html)
     assert result == ""
 
 
-def test_ruby_basic(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_basic(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rt>kanji</rt></ruby>"
     result = convert(html)
     assert result == "漢字(kanji)"
 
 
-def test_ruby_with_rb(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_rb(convert: Callable[..., str]) -> None:
     html = "<ruby><rb>漢字</rb><rt>kanji</rt></ruby>"
     result = convert(html)
     assert result == "漢字(kanji)"
 
 
-def test_ruby_with_fallback_rp(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_fallback_rp(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rp>(</rp><rt>kanji</rt><rp>)</rp></ruby>"
     result = convert(html)
     assert result == "漢字(kanji)"
 
 
-def test_ruby_complex_structure(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_complex_structure(convert: Callable[..., str]) -> None:
     html = "<ruby><rb>東京</rb><rp>(</rp><rt>とうきょう</rt><rp>)</rp></ruby>"
     result = convert(html)
     assert result == "東京(とうきょう)"
 
 
-def test_ruby_multiple_readings(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_multiple_readings(convert: Callable[..., str]) -> None:
     html = "<ruby><rb>漢</rb><rt>kan</rt><rb>字</rb><rt>ji</rt></ruby>"
     result = convert(html)
     assert result == "漢(kan)字(ji)"
 
 
-def test_ruby_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_inline_mode(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rt>kanji</rt></ruby>"
     result = convert(html, convert_as_inline=True)
     assert result == "漢字(kanji)"
 
 
-def test_ruby_block_mode(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_block_mode(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rt>kanji</rt></ruby>"
     result = convert(html, convert_as_inline=False)
     assert result == "漢字(kanji)"
 
 
-def test_ruby_nested_in_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_nested_in_paragraph(convert: Callable[..., str]) -> None:
     html = "<p>This is <ruby>漢字<rt>kanji</rt></ruby> text.</p>"
     result = convert(html)
     assert result == "This is 漢字(kanji) text.\n\n"
 
 
-def test_ruby_with_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_whitespace(convert: Callable[..., str]) -> None:
     html = "<ruby> 漢字 <rt> kanji </rt> </ruby>"
     result = convert(html)
     assert result == "漢字 (kanji)"
 
 
-def test_ruby_empty_elements(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_empty_elements(convert: Callable[..., str]) -> None:
     html = "<ruby><rb></rb><rt></rt></ruby>"
     result = convert(html)
     assert result == "()"
 
 
-def test_ruby_only_base_text(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_only_base_text(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字</ruby>"
     result = convert(html)
     assert result == "漢字"
 
 
-def test_ruby_only_annotation(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_only_annotation(convert: Callable[..., str]) -> None:
     html = "<ruby><rt>kanji</rt></ruby>"
     result = convert(html)
     assert result == "(kanji)"
 
 
-def test_ruby_with_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_formatting(convert: Callable[..., str]) -> None:
     html = "<ruby><strong>漢字</strong><rt><em>kanji</em></rt></ruby>"
     result = convert(html)
     assert result == "**漢字**(*kanji*)"
 
 
-def test_ruby_multiple_in_sentence(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_multiple_in_sentence(convert: Callable[..., str]) -> None:
     html = "I love <ruby>寿司<rt>sushi</rt></ruby> and <ruby>刺身<rt>sashimi</rt></ruby>!"
     result = convert(html)
     assert result == "I love 寿司(sushi) and 刺身(sashimi)!"
 
 
-def test_ruby_with_mixed_content(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_mixed_content(convert: Callable[..., str]) -> None:
     html = "<ruby>東<rb>京</rb>都<rt>とう<strong>きょう</strong>と</rt></ruby>"
     result = convert(html)
     assert result == "東京都(とう**きょう**と)"
 
 
-def test_rb_standalone(convert: Callable[[str, ...], str]) -> None:
+def test_rb_standalone(convert: Callable[..., str]) -> None:
     html = "<rb>漢字</rb>"
     result = convert(html)
     assert result == "漢字"
 
 
-def test_rb_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rb_inline_mode(convert: Callable[..., str]) -> None:
     html = "<rb>漢字</rb>"
     result = convert(html, convert_as_inline=True)
     assert result == "漢字"
 
 
-def test_rb_block_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rb_block_mode(convert: Callable[..., str]) -> None:
     html = "<rb>漢字</rb>"
     result = convert(html, convert_as_inline=False)
     assert result == "漢字"
 
 
-def test_rt_standalone(convert: Callable[[str, ...], str]) -> None:
+def test_rt_standalone(convert: Callable[..., str]) -> None:
     html = "<rt>kanji</rt>"
     result = convert(html)
     assert result == "(kanji)"
 
 
-def test_rt_with_surrounding_rp(convert: Callable[[str, ...], str]) -> None:
+def test_rt_with_surrounding_rp(convert: Callable[..., str]) -> None:
     html = "<rp>(</rp><rt>kanji</rt><rp>)</rp>"
     result = convert(html)
     assert result == "(kanji)"
 
 
-def test_rt_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rt_inline_mode(convert: Callable[..., str]) -> None:
     html = "<rt>kanji</rt>"
     result = convert(html, convert_as_inline=True)
     assert result == "(kanji)"
 
 
-def test_rt_block_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rt_block_mode(convert: Callable[..., str]) -> None:
     html = "<rt>kanji</rt>"
     result = convert(html, convert_as_inline=False)
     assert result == "(kanji)"
 
 
-def test_rp_standalone(convert: Callable[[str, ...], str]) -> None:
+def test_rp_standalone(convert: Callable[..., str]) -> None:
     html = "<rp>(</rp>"
     result = convert(html)
     assert result == "("
 
 
-def test_rp_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rp_inline_mode(convert: Callable[..., str]) -> None:
     html = "<rp>)</rp>"
     result = convert(html, convert_as_inline=True)
     assert result == ")"
 
 
-def test_rp_block_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rp_block_mode(convert: Callable[..., str]) -> None:
     html = "<rp>(</rp>"
     result = convert(html, convert_as_inline=False)
     assert result == "("
 
 
-def test_rtc_standalone(convert: Callable[[str, ...], str]) -> None:
+def test_rtc_standalone(convert: Callable[..., str]) -> None:
     html = "<rtc>annotation</rtc>"
     result = convert(html)
     assert result == "annotation"
 
 
-def test_rtc_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rtc_inline_mode(convert: Callable[..., str]) -> None:
     html = "<rtc>annotation</rtc>"
     result = convert(html, convert_as_inline=True)
     assert result == "annotation"
 
 
-def test_rtc_block_mode(convert: Callable[[str, ...], str]) -> None:
+def test_rtc_block_mode(convert: Callable[..., str]) -> None:
     html = "<rtc>annotation</rtc>"
     result = convert(html, convert_as_inline=False)
     assert result == "annotation"
 
 
-def test_nested_ruby_elements(convert: Callable[[str, ...], str]) -> None:
+def test_nested_ruby_elements(convert: Callable[..., str]) -> None:
     html = "<ruby><ruby>漢<rt>kan</rt></ruby><rt>字</rt></ruby>"
     result = convert(html)
     assert result == "漢(kan)(字)"
 
 
-def test_ruby_with_line_breaks(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_line_breaks(convert: Callable[..., str]) -> None:
     html = "<ruby>\n漢字\n<rt>\nkanji\n</rt>\n</ruby>"
     result = convert(html)
     assert result == "漢字(kanji)"
 
 
-def test_ruby_with_special_characters(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_special_characters(convert: Callable[..., str]) -> None:
     html = "<ruby>*test*<rt>_annotation_</rt></ruby>"
     result = convert(html)
     assert result == "\\*test\\*(\\_annotation\\_)"
 
 
-def test_ruby_with_links(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_links(convert: Callable[..., str]) -> None:
     html = '<ruby><a href="https://example.com">漢字</a><rt>kanji</rt></ruby>'
     result = convert(html)
     assert result == "[漢字](https://example.com)(kanji)"
 
 
-def test_ruby_in_table(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_in_table(convert: Callable[..., str]) -> None:
     html = "<table><tr><td><ruby>漢字<rt>kanji</rt></ruby></td></tr></table>"
     result = convert(html)
     assert "漢字(kanji)" in result
 
 
-def test_ruby_in_list(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_in_list(convert: Callable[..., str]) -> None:
     html = "<ul><li><ruby>漢字<rt>kanji</rt></ruby></li></ul>"
     result = convert(html)
     assert "* 漢字(kanji)" in result
 
 
-def test_multiple_rt_elements(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_rt_elements(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rt>kan</rt><rt>ji</rt></ruby>"
     result = convert(html)
     assert result == "漢字(kan)(ji)"
 
 
-def test_ruby_with_rtc_and_rt(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_rtc_and_rt(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rt>kanji</rt><rtc>Chinese characters</rtc></ruby>"
     result = convert(html)
     assert result == "漢字(kanji)Chinese characters"
 
 
-def test_complex_ruby_structure(convert: Callable[[str, ...], str]) -> None:
+def test_complex_ruby_structure(convert: Callable[..., str]) -> None:
     html = """<ruby>
         <rb>漢</rb>
         <rb>字</rb>
@@ -1430,271 +1430,271 @@ def test_complex_ruby_structure(convert: Callable[[str, ...], str]) -> None:
     assert result == "漢字((kan)(ji))Chinese characters"
 
 
-def test_ruby_with_empty_rt(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_empty_rt(convert: Callable[..., str]) -> None:
     html = "<ruby>漢字<rt></rt></ruby>"
     result = convert(html)
     assert result == "漢字()"
 
 
-def test_ruby_with_only_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_with_only_spaces(convert: Callable[..., str]) -> None:
     html = "<ruby>   <rt>   </rt>   </ruby>"
     result = convert(html)
     assert result == "()"
 
 
-def test_abbr_basic(convert: Callable[[str, ...], str]) -> None:
+def test_abbr_basic(convert: Callable[..., str]) -> None:
     html = "<abbr>HTML</abbr>"
     result = convert(html)
     assert result == "HTML"
 
 
-def test_abbr_with_title(convert: Callable[[str, ...], str]) -> None:
+def test_abbr_with_title(convert: Callable[..., str]) -> None:
     html = '<abbr title="HyperText Markup Language">HTML</abbr>'
     result = convert(html)
     assert result == "HTML (HyperText Markup Language)"
 
 
-def test_abbr_with_empty_title(convert: Callable[[str, ...], str]) -> None:
+def test_abbr_with_empty_title(convert: Callable[..., str]) -> None:
     html = '<abbr title="">HTML</abbr>'
     result = convert(html)
     assert result == "HTML"
 
 
-def test_abbr_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_abbr_inline_mode(convert: Callable[..., str]) -> None:
     html = '<abbr title="HyperText Markup Language">HTML</abbr>'
     result = convert(html, convert_as_inline=True)
     assert result == "HTML (HyperText Markup Language)"
 
 
-def test_abbr_nested_content(convert: Callable[[str, ...], str]) -> None:
+def test_abbr_nested_content(convert: Callable[..., str]) -> None:
     html = '<p>Learn <abbr title="HyperText Markup Language">HTML</abbr> today!</p>'
     result = convert(html)
     assert result == "Learn HTML (HyperText Markup Language) today!\n\n"
 
 
-def test_time_basic(convert: Callable[[str, ...], str]) -> None:
+def test_time_basic(convert: Callable[..., str]) -> None:
     html = "<time>2023-12-25</time>"
     result = convert(html)
     assert result == "2023\\-12\\-25"
 
 
-def test_time_with_datetime(convert: Callable[[str, ...], str]) -> None:
+def test_time_with_datetime(convert: Callable[..., str]) -> None:
     html = '<time datetime="2023-12-25T10:30:00">Christmas Day</time>'
     result = convert(html)
     assert result == "Christmas Day"
 
 
-def test_time_with_empty_datetime(convert: Callable[[str, ...], str]) -> None:
+def test_time_with_empty_datetime(convert: Callable[..., str]) -> None:
     html = '<time datetime="">December 25</time>'
     result = convert(html)
     assert result == "December 25"
 
 
-def test_time_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_time_inline_mode(convert: Callable[..., str]) -> None:
     html = '<time datetime="2023-12-25">Christmas</time>'
     result = convert(html, convert_as_inline=True)
     assert result == "Christmas"
 
 
-def test_time_in_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_time_in_paragraph(convert: Callable[..., str]) -> None:
     html = '<p>The event is on <time datetime="2023-12-25">Christmas Day</time>.</p>'
     result = convert(html)
     assert result == "The event is on Christmas Day.\n\n"
 
 
-def test_data_basic(convert: Callable[[str, ...], str]) -> None:
+def test_data_basic(convert: Callable[..., str]) -> None:
     html = "<data>Product Name</data>"
     result = convert(html)
     assert result == "Product Name"
 
 
-def test_data_with_value(convert: Callable[[str, ...], str]) -> None:
+def test_data_with_value(convert: Callable[..., str]) -> None:
     html = '<data value="12345">Product Name</data>'
     result = convert(html)
     assert result == "Product Name"
 
 
-def test_data_with_empty_value(convert: Callable[[str, ...], str]) -> None:
+def test_data_with_empty_value(convert: Callable[..., str]) -> None:
     html = '<data value="">Product</data>'
     result = convert(html)
     assert result == "Product"
 
 
-def test_data_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_data_inline_mode(convert: Callable[..., str]) -> None:
     html = '<data value="12345">Product</data>'
     result = convert(html, convert_as_inline=True)
     assert result == "Product"
 
 
-def test_data_in_list(convert: Callable[[str, ...], str]) -> None:
+def test_data_in_list(convert: Callable[..., str]) -> None:
     html = '<ul><li><data value="A001">Product A</data></li><li><data value="B002">Product B</data></li></ul>'
     result = convert(html)
     assert result == "* Product A\n* Product B\n"
 
 
-def test_ins_basic(convert: Callable[[str, ...], str]) -> None:
+def test_ins_basic(convert: Callable[..., str]) -> None:
     html = "<ins>This text was added</ins>"
     result = convert(html)
     assert result == "==This text was added=="
 
 
-def test_ins_with_cite(convert: Callable[[str, ...], str]) -> None:
+def test_ins_with_cite(convert: Callable[..., str]) -> None:
     html = '<ins cite="https://example.com">Added text</ins>'
     result = convert(html)
     assert result == "==Added text=="
 
 
-def test_ins_with_datetime(convert: Callable[[str, ...], str]) -> None:
+def test_ins_with_datetime(convert: Callable[..., str]) -> None:
     html = '<ins datetime="2023-12-25">Added on Christmas</ins>'
     result = convert(html)
     assert result == "==Added on Christmas=="
 
 
-def test_ins_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_ins_inline_mode(convert: Callable[..., str]) -> None:
     html = "<ins>Added text</ins>"
     result = convert(html, convert_as_inline=True)
     assert result == "==Added text=="
 
 
-def test_ins_in_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_ins_in_paragraph(convert: Callable[..., str]) -> None:
     html = "<p>Original text <ins>with addition</ins> and more.</p>"
     result = convert(html)
     assert result == "Original text ==with addition== and more.\n\n"
 
 
-def test_var_basic(convert: Callable[[str, ...], str]) -> None:
+def test_var_basic(convert: Callable[..., str]) -> None:
     html = "<var>x</var>"
     result = convert(html)
     assert result == "*x*"
 
 
-def test_var_in_code(convert: Callable[[str, ...], str]) -> None:
+def test_var_in_code(convert: Callable[..., str]) -> None:
     html = "<p>Set <var>username</var> to your login name.</p>"
     result = convert(html)
     assert result == "Set *username* to your login name.\n\n"
 
 
-def test_var_mathematical(convert: Callable[[str, ...], str]) -> None:
+def test_var_mathematical(convert: Callable[..., str]) -> None:
     html = "<p>If <var>x</var> = 5, then <var>y</var> = <var>x</var> + 3.</p>"
     result = convert(html)
     assert result == "If *x* \\= 5, then *y* \\= *x* \\+ 3\\.\n\n"
 
 
-def test_var_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_var_inline_mode(convert: Callable[..., str]) -> None:
     html = "<var>variable</var>"
     result = convert(html, convert_as_inline=True)
     assert result == "*variable*"
 
 
-def test_dfn_basic(convert: Callable[[str, ...], str]) -> None:
+def test_dfn_basic(convert: Callable[..., str]) -> None:
     html = "<dfn>API</dfn>"
     result = convert(html)
     assert result == "*API*"
 
 
-def test_dfn_with_title(convert: Callable[[str, ...], str]) -> None:
+def test_dfn_with_title(convert: Callable[..., str]) -> None:
     html = '<dfn title="Application Programming Interface">API</dfn>'
     result = convert(html)
     assert result == "*API*"
 
 
-def test_dfn_in_definition_list(convert: Callable[[str, ...], str]) -> None:
+def test_dfn_in_definition_list(convert: Callable[..., str]) -> None:
     html = "<dl><dt><dfn>API</dfn></dt><dd>Application Programming Interface</dd></dl>"
     result = convert(html)
     assert result == "*API*\n:   Application Programming Interface\n\n"
 
 
-def test_dfn_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_dfn_inline_mode(convert: Callable[..., str]) -> None:
     html = "<dfn>term</dfn>"
     result = convert(html, convert_as_inline=True)
     assert result == "*term*"
 
 
-def test_bdi_basic(convert: Callable[[str, ...], str]) -> None:
+def test_bdi_basic(convert: Callable[..., str]) -> None:
     html = "<bdi>عربي</bdi>"
     result = convert(html)
     assert result == "عربي"
 
 
-def test_bdo_basic(convert: Callable[[str, ...], str]) -> None:
+def test_bdo_basic(convert: Callable[..., str]) -> None:
     html = '<bdo dir="rtl">English text</bdo>'
     result = convert(html)
     assert result == "English text"
 
 
-def test_bdi_mixed_text(convert: Callable[[str, ...], str]) -> None:
+def test_bdi_mixed_text(convert: Callable[..., str]) -> None:
     html = "<p>User <bdi>إيان</bdi> scored 90 points.</p>"
     result = convert(html)
     assert result == "User إيان scored 90 points.\n\n"
 
 
-def test_bdo_with_direction(convert: Callable[[str, ...], str]) -> None:
+def test_bdo_with_direction(convert: Callable[..., str]) -> None:
     html = '<p>The title is <bdo dir="rtl">مرحبا</bdo> in Arabic.</p>'
     result = convert(html)
     assert result == "The title is مرحبا in Arabic.\n\n"
 
 
-def test_bdi_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_bdi_inline_mode(convert: Callable[..., str]) -> None:
     html = "<bdi>نص عربي</bdi>"
     result = convert(html, convert_as_inline=True)
     assert result == "نص عربي"
 
 
-def test_small_basic(convert: Callable[[str, ...], str]) -> None:
+def test_small_basic(convert: Callable[..., str]) -> None:
     html = "<small>Fine print</small>"
     result = convert(html)
     assert result == "Fine print"
 
 
-def test_small_copyright(convert: Callable[[str, ...], str]) -> None:
+def test_small_copyright(convert: Callable[..., str]) -> None:
     html = "<p>© 2023 Company Name. <small>All rights reserved.</small></p>"
     result = convert(html)
     assert result == "© 2023 Company Name. All rights reserved.\n\n"
 
 
-def test_small_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_small_inline_mode(convert: Callable[..., str]) -> None:
     html = "<small>Legal disclaimer</small>"
     result = convert(html, convert_as_inline=True)
     assert result == "Legal disclaimer"
 
 
-def test_u_basic(convert: Callable[[str, ...], str]) -> None:
+def test_u_basic(convert: Callable[..., str]) -> None:
     html = "<u>Underlined text</u>"
     result = convert(html)
     assert result == "Underlined text"
 
 
-def test_u_misspelling(convert: Callable[[str, ...], str]) -> None:
+def test_u_misspelling(convert: Callable[..., str]) -> None:
     html = "<p>This word is <u>mispelled</u>.</p>"
     result = convert(html)
     assert result == "This word is mispelled.\n\n"
 
 
-def test_u_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_u_inline_mode(convert: Callable[..., str]) -> None:
     html = "<u>underlined</u>"
     result = convert(html, convert_as_inline=True)
     assert result == "underlined"
 
 
-def test_wbr_basic(convert: Callable[[str, ...], str]) -> None:
+def test_wbr_basic(convert: Callable[..., str]) -> None:
     html = "super<wbr>cali<wbr>fragilistic"
     result = convert(html)
     assert result == "supercalifragilistic"
 
 
-def test_wbr_long_url(convert: Callable[[str, ...], str]) -> None:
+def test_wbr_long_url(convert: Callable[..., str]) -> None:
     html = "<p>Visit https://www.<wbr>example.<wbr>com/very/<wbr>long/<wbr>path</p>"
     result = convert(html)
     assert result == "Visit https://www.example.com/very/long/path\n\n"
 
 
-def test_wbr_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_wbr_inline_mode(convert: Callable[..., str]) -> None:
     html = "long<wbr>word"
     result = convert(html, convert_as_inline=True)
     assert result == "longword"
 
 
-def test_mixed_semantic_elements(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_semantic_elements(convert: Callable[..., str]) -> None:
     html = """<article>
         <h2>Programming Concepts</h2>
         <p>An <dfn>API</dfn> (<abbr title="Application Programming Interface">API</abbr>)
@@ -1717,7 +1717,7 @@ Last updated: December 25, 2023
     assert result == expected
 
 
-def test_complex_nested_semantic_elements(convert: Callable[[str, ...], str]) -> None:
+def test_complex_nested_semantic_elements(convert: Callable[..., str]) -> None:
     html = '<p>The <dfn><abbr title="Application Programming Interface">API</abbr></dfn> documentation has been <ins>updated with <var>new_parameter</var></ins>.</p>'
     result = convert(html)
     assert (
@@ -1726,68 +1726,68 @@ def test_complex_nested_semantic_elements(convert: Callable[[str, ...], str]) ->
     )
 
 
-def test_mixed_semantic_elements_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_semantic_elements_inline_mode(convert: Callable[..., str]) -> None:
     html = '<abbr title="HyperText Markup Language">HTML</abbr> and <var>css</var> with <ins>updates</ins>'
     result = convert(html, convert_as_inline=True)
     assert result == "HTML (HyperText Markup Language) and *css* with ==updates=="
 
 
-def test_multiple_empty_semantic_elements(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_empty_semantic_elements(convert: Callable[..., str]) -> None:
     html = "<p>Empty elements: <abbr></abbr> <var></var> <ins></ins> <dfn></dfn></p>"
     result = convert(html)
     assert result == "Empty elements: \n\n"
 
 
-def test_whitespace_handling_semantic(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_handling_semantic(convert: Callable[..., str]) -> None:
     html = "<p>Spaces around <var>  variable  </var> and <abbr title='  title  '>  abbr  </abbr></p>"
     result = convert(html)
     assert result == "Spaces around  *variable*  and abbr (title)\n\n"
 
 
-def test_figure_basic(convert: Callable[[str, ...], str]) -> None:
+def test_figure_basic(convert: Callable[..., str]) -> None:
     html = '<figure><img src="image.jpg" alt="Test image"></figure>'
     result = convert(html)
     assert result == "![Test image](image.jpg)\n\n"
 
 
-def test_figure_with_caption(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_caption(convert: Callable[..., str]) -> None:
     html = '<figure><img src="test.jpg"><figcaption>Image caption</figcaption></figure>'
     result = convert(html)
     expected = "![](test.jpg)\n\n*Image caption*\n\n"
     assert result == expected
 
 
-def test_figure_with_id(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_id(convert: Callable[..., str]) -> None:
     html = '<figure id="fig1"><img src="chart.png"></figure>'
     result = convert(html)
     assert result == "![](chart.png)\n\n"
 
 
-def test_figure_with_class(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_class(convert: Callable[..., str]) -> None:
     html = '<figure class="photo"><img src="photo.jpg"></figure>'
     result = convert(html)
     assert result == "![](photo.jpg)\n\n"
 
 
-def test_figure_with_multiple_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_multiple_attributes(convert: Callable[..., str]) -> None:
     html = '<figure id="fig2" class="diagram"><img src="diagram.svg"></figure>'
     result = convert(html)
     assert result == "![](diagram.svg)\n\n"
 
 
-def test_figure_empty(convert: Callable[[str, ...], str]) -> None:
+def test_figure_empty(convert: Callable[..., str]) -> None:
     html = "<figure></figure>"
     result = convert(html)
     assert result == ""
 
 
-def test_figure_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_figure_inline_mode(convert: Callable[..., str]) -> None:
     html = '<figure><img src="inline.jpg" alt="Inline image"></figure>'
     result = convert(html, convert_as_inline=True)
     assert result == "Inline image"
 
 
-def test_figure_with_complex_content(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_complex_content(convert: Callable[..., str]) -> None:
     html = """<figure>
         <img src="main.jpg" alt="Main image">
         <figcaption>
@@ -1799,7 +1799,7 @@ def test_figure_with_complex_content(convert: Callable[[str, ...], str]) -> None
     assert result == expected
 
 
-def test_figure_with_multiple_images(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_multiple_images(convert: Callable[..., str]) -> None:
     html = """<figure>
         <img src="before.jpg" alt="Before">
         <img src="after.jpg" alt="After">
@@ -1810,7 +1810,7 @@ def test_figure_with_multiple_images(convert: Callable[[str, ...], str]) -> None
     assert result == expected
 
 
-def test_figure_with_nested_elements(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_nested_elements(convert: Callable[..., str]) -> None:
     html = """<figure id="stats">
         <table>
             <tr><th>Year</th><th>Sales</th></tr>
@@ -1823,60 +1823,60 @@ def test_figure_with_nested_elements(convert: Callable[[str, ...], str]) -> None
     assert result == expected
 
 
-def test_hgroup_basic(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_basic(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>Main Title</h1><h2>Subtitle</h2></hgroup>"
     result = convert(html)
     expected = "Main Title\n==========\n\nSubtitle\n--------\n\n"
     assert result == expected
 
 
-def test_hgroup_multiple_headings(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_multiple_headings(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>Title</h1><h2>Subtitle</h2><h3>Section</h3></hgroup>"
     result = convert(html)
     expected = "Title\n=====\n\nSubtitle\n--------\n\n### Section\n\n"
     assert result == expected
 
 
-def test_hgroup_empty(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_empty(convert: Callable[..., str]) -> None:
     html = "<hgroup></hgroup>"
     result = convert(html)
     assert result == ""
 
 
-def test_hgroup_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_inline_mode(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>Inline Title</h1></hgroup>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline Title"
 
 
-def test_hgroup_with_atx_headings(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_with_atx_headings(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>Main</h1><h2>Sub</h2></hgroup>"
     result = convert(html, heading_style="atx")
     expected = "# Main\n\n## Sub\n\n"
     assert result == expected
 
 
-def test_hgroup_excessive_spacing(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_excessive_spacing(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>Title</h1><p></p><p></p><h2>Subtitle</h2></hgroup>"
     result = convert(html)
     expected = "Title\n=====\n\nSubtitle\n--------\n\n"
     assert result == expected
 
 
-def test_hgroup_with_formatted_headings(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_with_formatted_headings(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>The <em>Amazing</em> Title</h1><h2>A <strong>Bold</strong> Subtitle</h2></hgroup>"
     result = convert(html)
     expected = "The *Amazing* Title\n===================\n\nA **Bold** Subtitle\n-------------------\n\n"
     assert result == expected
 
 
-def test_picture_basic(convert: Callable[[str, ...], str]) -> None:
+def test_picture_basic(convert: Callable[..., str]) -> None:
     html = '<picture><img src="image.jpg" alt="Test"></picture>'
     result = convert(html)
     assert result == "![Test](image.jpg)"
 
 
-def test_picture_with_source(convert: Callable[[str, ...], str]) -> None:
+def test_picture_with_source(convert: Callable[..., str]) -> None:
     html = """<picture>
         <source srcset="large.jpg" media="(min-width: 800px)">
         <img src="small.jpg" alt="Responsive image">
@@ -1885,7 +1885,7 @@ def test_picture_with_source(convert: Callable[[str, ...], str]) -> None:
     assert result == "![Responsive image](small.jpg)"
 
 
-def test_picture_multiple_sources(convert: Callable[[str, ...], str]) -> None:
+def test_picture_multiple_sources(convert: Callable[..., str]) -> None:
     html = """<picture>
         <source srcset="image.webp" type="image/webp">
         <source srcset="image.jpg" type="image/jpeg">
@@ -1895,7 +1895,7 @@ def test_picture_multiple_sources(convert: Callable[[str, ...], str]) -> None:
     assert result == "![Multi-format](fallback.jpg)"
 
 
-def test_picture_complex_srcset(convert: Callable[[str, ...], str]) -> None:
+def test_picture_complex_srcset(convert: Callable[..., str]) -> None:
     html = """<picture>
         <source srcset="small.jpg 480w, medium.jpg 800w, large.jpg 1200w"
                 media="(min-width: 600px)">
@@ -1905,19 +1905,19 @@ def test_picture_complex_srcset(convert: Callable[[str, ...], str]) -> None:
     assert result == "![](default.jpg)"
 
 
-def test_picture_no_img(convert: Callable[[str, ...], str]) -> None:
+def test_picture_no_img(convert: Callable[..., str]) -> None:
     html = '<picture><source srcset="test.jpg"></picture>'
     result = convert(html)
     assert result == ""
 
 
-def test_picture_empty(convert: Callable[[str, ...], str]) -> None:
+def test_picture_empty(convert: Callable[..., str]) -> None:
     html = "<picture></picture>"
     result = convert(html)
     assert result == ""
 
 
-def test_picture_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_picture_inline_mode(convert: Callable[..., str]) -> None:
     html = """<picture>
         <source srcset="large.jpg" media="(min-width: 800px)">
         <img src="small.jpg" alt="Test">
@@ -1926,7 +1926,7 @@ def test_picture_inline_mode(convert: Callable[[str, ...], str]) -> None:
     assert result == "Test"
 
 
-def test_picture_with_sizes(convert: Callable[[str, ...], str]) -> None:
+def test_picture_with_sizes(convert: Callable[..., str]) -> None:
     html = """<picture>
         <source srcset="img-480.jpg 480w, img-800.jpg 800w"
                 sizes="(max-width: 600px) 480px, 800px">
@@ -1936,7 +1936,7 @@ def test_picture_with_sizes(convert: Callable[[str, ...], str]) -> None:
     assert result == "![](default.jpg)"
 
 
-def test_figure_in_article(convert: Callable[[str, ...], str]) -> None:
+def test_figure_in_article(convert: Callable[..., str]) -> None:
     html = """<article>
         <h1>Article Title</h1>
         <figure id="main-image">
@@ -1950,7 +1950,7 @@ def test_figure_in_article(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_hgroup_in_header(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_in_header(convert: Callable[..., str]) -> None:
     html = """<header>
         <hgroup>
             <h1>Site Title</h1>
@@ -1963,7 +1963,7 @@ def test_hgroup_in_header(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_picture_in_figure(convert: Callable[[str, ...], str]) -> None:
+def test_picture_in_figure(convert: Callable[..., str]) -> None:
     html = """<figure>
         <picture>
             <source srcset="large.webp" type="image/webp">
@@ -1976,7 +1976,7 @@ def test_picture_in_figure(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_multiple_figures(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_figures(convert: Callable[..., str]) -> None:
     html = """
     <figure id="fig1">
         <img src="image1.jpg">
@@ -1992,7 +1992,7 @@ def test_multiple_figures(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_nested_structural_elements(convert: Callable[[str, ...], str]) -> None:
+def test_nested_structural_elements(convert: Callable[..., str]) -> None:
     html = """<section>
         <hgroup>
             <h1>Section Title</h1>
@@ -2011,21 +2011,21 @@ def test_nested_structural_elements(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_figure_with_special_characters(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_special_characters(convert: Callable[..., str]) -> None:
     html = '<figure><img src="test.jpg"><figcaption>Caption with *asterisks* and _underscores_</figcaption></figure>'
     result = convert(html)
     expected = "![](test.jpg)\n\n*Caption with \\*asterisks\\* and \\_underscores\\_*\n\n"
     assert result == expected
 
 
-def test_hgroup_single_heading(convert: Callable[[str, ...], str]) -> None:
+def test_hgroup_single_heading(convert: Callable[..., str]) -> None:
     html = "<hgroup><h1>Only Title</h1></hgroup>"
     result = convert(html)
     expected = "Only Title\n==========\n\n"
     assert result == expected
 
 
-def test_picture_malformed_source(convert: Callable[[str, ...], str]) -> None:
+def test_picture_malformed_source(convert: Callable[..., str]) -> None:
     html = """<picture>
         <source>
         <source srcset="">
@@ -2035,7 +2035,7 @@ def test_picture_malformed_source(convert: Callable[[str, ...], str]) -> None:
     assert result == "![](valid.jpg)"
 
 
-def test_figure_whitespace_handling(convert: Callable[[str, ...], str]) -> None:
+def test_figure_whitespace_handling(convert: Callable[..., str]) -> None:
     html = """<figure>
 
         <img src="test.jpg">
@@ -2050,7 +2050,7 @@ def test_figure_whitespace_handling(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_empty_elements_with_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_empty_elements_with_attributes(convert: Callable[..., str]) -> None:
     html1 = '<figure id="empty-fig"></figure>'
     assert convert(html1) == ""
 
@@ -2061,7 +2061,7 @@ def test_empty_elements_with_attributes(convert: Callable[[str, ...], str]) -> N
     assert convert(html3) == ""
 
 
-def test_figure_with_pre_content(convert: Callable[[str, ...], str]) -> None:
+def test_figure_with_pre_content(convert: Callable[..., str]) -> None:
     html = """<figure>
         <pre><code>function example() {
   return 42;
@@ -2088,7 +2088,7 @@ def test_figure_with_pre_content(convert: Callable[[str, ...], str]) -> None:
         ("<ruby>漢字<rt>kanji</rt></ruby>", "漢字(kanji)"),
     ],
 )
-def test_element_patterns(html: str, expected: str, convert: Callable[[str, ...], str]) -> None:
+def test_element_patterns(html: str, expected: str, convert: Callable[..., str]) -> None:
     result = convert(html)
     assert expected in result
 
@@ -2128,12 +2128,12 @@ def test_element_patterns(html: str, expected: str, convert: Callable[[str, ...]
         ("<picture></picture>", True),
     ],
 )
-def test_empty_elements(html: str, expected_empty: bool, convert: Callable[[str, ...], str]) -> None:
+def test_empty_elements(html: str, expected_empty: bool, convert: Callable[..., str]) -> None:
     result = convert(html)
     assert (result == "") == expected_empty
 
 
-def test_blockquote_with_cite_in_list(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_with_cite_in_list(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             Item with blockquote:
@@ -2147,19 +2147,19 @@ def test_blockquote_with_cite_in_list(convert: Callable[[str, ...], str]) -> Non
     assert "— <https://example.com>" in result
 
 
-def test_mark_with_unsupported_highlight_style(convert: Callable[[str, ...], str]) -> None:
+def test_mark_with_unsupported_highlight_style(convert: Callable[..., str]) -> None:
     html = "<mark>highlighted text</mark>"
     result = convert(html, highlight_style="unsupported")
     assert result == "highlighted text"
 
 
-def test_empty_pre_element(convert: Callable[[str, ...], str]) -> None:
+def test_empty_pre_element(convert: Callable[..., str]) -> None:
     html = "<pre></pre>"
     result = convert(html)
     assert result == ""
 
 
-def test_media_element_without_src_but_with_text(convert: Callable[[str, ...], str]) -> None:
+def test_media_element_without_src_but_with_text(convert: Callable[..., str]) -> None:
     html = "<video>Your browser doesn't support video</video>"
     result = convert(html)
     assert "Your browser doesn't support video" in result
@@ -2169,7 +2169,7 @@ def test_media_element_without_src_but_with_text(convert: Callable[[str, ...], s
     assert "Audio not supported" in result
 
 
-def test_paragraph_directly_in_list(convert: Callable[[str, ...], str]) -> None:
+def test_paragraph_directly_in_list(convert: Callable[..., str]) -> None:
     html = """<ul>
         <p>Line 1\n\nLine 2</p>
     </ul>"""
@@ -2178,7 +2178,7 @@ def test_paragraph_directly_in_list(convert: Callable[[str, ...], str]) -> None:
     assert "Line 2" in result
 
 
-def test_paragraph_in_list_with_blank_lines(convert: Callable[[str, ...], str]) -> None:
+def test_paragraph_in_list_with_blank_lines(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <p>First line\n\nSecond line\n\n\nThird line</p>
@@ -2190,7 +2190,7 @@ def test_paragraph_in_list_with_blank_lines(convert: Callable[[str, ...], str]) 
     assert "Third line" in result
 
 
-def test_blockquote_directly_under_list(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_directly_under_list(convert: Callable[..., str]) -> None:
     html = """<ul>
         <blockquote>Quote\n\nWith blank lines</blockquote>
     </ul>"""
@@ -2198,7 +2198,7 @@ def test_blockquote_directly_under_list(convert: Callable[[str, ...], str]) -> N
     assert "Quote" in result
 
 
-def test_blockquote_deeply_nested_in_li_needs_traversal(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_deeply_nested_in_li_needs_traversal(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <div>
@@ -2212,14 +2212,14 @@ def test_blockquote_deeply_nested_in_li_needs_traversal(convert: Callable[[str, 
     assert "> Nested quote" in result
 
 
-def test_checkbox_with_string_content(convert: Callable[[str, ...], str]) -> None:
+def test_checkbox_with_string_content(convert: Callable[..., str]) -> None:
     html = '<ul><li><input type="checkbox">checkbox text content</input> List item text</li></ul>'
     result = convert(html)
     assert "[ ]" in result
     assert "List item text" in result
 
 
-def test_paragraph_in_deeply_nested_li(convert: Callable[[str, ...], str]) -> None:
+def test_paragraph_in_deeply_nested_li(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <div>
@@ -2235,7 +2235,7 @@ def test_paragraph_in_deeply_nested_li(convert: Callable[[str, ...], str]) -> No
     assert "Second paragraph" in result
 
 
-def test_paragraph_deeply_nested_needs_traversal(convert: Callable[[str, ...], str]) -> None:
+def test_paragraph_deeply_nested_needs_traversal(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <div>
@@ -2251,7 +2251,7 @@ def test_paragraph_deeply_nested_needs_traversal(convert: Callable[[str, ...], s
     assert "Deeply nested paragraph" in result
 
 
-def test_blockquote_in_list_with_empty_lines(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_in_list_with_empty_lines(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <blockquote>Line 1\n\nLine 2\n\n\nLine 3</blockquote>
@@ -2263,68 +2263,68 @@ def test_blockquote_in_list_with_empty_lines(convert: Callable[[str, ...], str])
     assert "Line 3" in result
 
 
-def test_iframe_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_inline_mode(convert: Callable[..., str]) -> None:
     html = '<iframe src="https://example.com/embed"></iframe>'
     result = convert(html, convert_as_inline=True)
     assert result == "[https://example.com/embed](https://example.com/embed)"
 
 
-def test_time_element_empty(convert: Callable[[str, ...], str]) -> None:
+def test_time_element_empty(convert: Callable[..., str]) -> None:
     html = "<time></time>"
     result = convert(html)
     assert result == ""
 
 
-def test_data_element_empty(convert: Callable[[str, ...], str]) -> None:
+def test_data_element_empty(convert: Callable[..., str]) -> None:
     html = "<data></data>"
     result = convert(html)
     assert result == ""
 
 
-def test_optgroup_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_optgroup_inline_mode(convert: Callable[..., str]) -> None:
     html = '<optgroup label="Group"><option>Option 1</option></optgroup>'
     result = convert(html, convert_as_inline=True)
     assert "Option 1" in result
 
 
-def test_optgroup_without_label(convert: Callable[[str, ...], str]) -> None:
+def test_optgroup_without_label(convert: Callable[..., str]) -> None:
     html = "<optgroup><option>Option 1</option><option>Option 2</option></optgroup>"
     result = convert(html)
     assert "Option 1" in result
     assert "Option 2" in result
 
 
-def test_optgroup_empty(convert: Callable[[str, ...], str]) -> None:
+def test_optgroup_empty(convert: Callable[..., str]) -> None:
     html = "<optgroup>  </optgroup>"
     result = convert(html)
     assert result == ""
 
 
-def test_ruby_element_empty(convert: Callable[[str, ...], str]) -> None:
+def test_ruby_element_empty(convert: Callable[..., str]) -> None:
     html = "<ruby>  </ruby>"
     result = convert(html)
     assert result == ""
 
 
-def test_rp_element_empty(convert: Callable[[str, ...], str]) -> None:
+def test_rp_element_empty(convert: Callable[..., str]) -> None:
     html = "<rp>  </rp>"
     result = convert(html)
     assert result == ""
 
 
-def test_rtc_element_empty(convert: Callable[[str, ...], str]) -> None:
+def test_rtc_element_empty(convert: Callable[..., str]) -> None:
     html = "<rtc>  </rtc>"
     result = convert(html)
     assert result == ""
 
 
-def test_legend_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_legend_inline_mode(convert: Callable[..., str]) -> None:
     html = "<legend>Form Legend</legend>"
     result = convert(html, convert_as_inline=True)
     assert result == "Form Legend"
 
 
-def test_iframe_without_src(convert: Callable[[str, ...], str]) -> None:
+def test_iframe_without_src(convert: Callable[..., str]) -> None:
     html = "<iframe></iframe>"
     result = convert(html)
     assert result == ""

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -11,45 +11,45 @@ if TYPE_CHECKING:
     from bs4.element import Tag
 
 
-def test_single_tag(convert: Callable[[str, ...], str]) -> None:
+def test_single_tag(convert: Callable[..., str]) -> None:
     assert convert("<span>Hello</span>") == "Hello"
 
 
-def test_soup(convert: Callable[[str, ...], str]) -> None:
+def test_soup(convert: Callable[..., str]) -> None:
     assert convert("<div><span>Hello</div></span>") == "Hello\n\n"
 
 
-def test_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace(convert: Callable[..., str]) -> None:
     assert convert(" a  b \t\t c ") == " a b c "
 
 
-def test_asterisks(convert: Callable[[str, ...], str]) -> None:
+def test_asterisks(convert: Callable[..., str]) -> None:
     assert convert("*hey*dude*") == r"\*hey\*dude\*"
     assert convert("*hey*dude*", escape_asterisks=False) == r"*hey*dude*"
 
 
-def test_underscore(convert: Callable[[str, ...], str]) -> None:
+def test_underscore(convert: Callable[..., str]) -> None:
     assert convert("_hey_dude_") == r"\_hey\_dude\_"
     assert convert("_hey_dude_", escape_underscores=False) == r"_hey_dude_"
 
 
-def test_xml_entities(convert: Callable[[str, ...], str]) -> None:
+def test_xml_entities(convert: Callable[..., str]) -> None:
     assert convert("&amp;") == r"\&"
 
 
-def test_named_entities(convert: Callable[[str, ...], str]) -> None:
+def test_named_entities(convert: Callable[..., str]) -> None:
     assert convert("&raquo;") == "\xbb"
 
 
-def test_hexadecimal_entities(convert: Callable[[str, ...], str]) -> None:
+def test_hexadecimal_entities(convert: Callable[..., str]) -> None:
     assert convert("&#x27;") == "\x27"
 
 
-def test_single_escaping_entities(convert: Callable[[str, ...], str]) -> None:
+def test_single_escaping_entities(convert: Callable[..., str]) -> None:
     assert convert("&amp;amp;") == r"\&amp;"
 
 
-def test_misc(convert: Callable[[str, ...], str]) -> None:
+def test_misc(convert: Callable[..., str]) -> None:
     assert convert("\\*") == r"\\\*"
     assert convert("<foo>") == ""
     assert convert("# foo") == r"\# foo"
@@ -79,22 +79,22 @@ def test_chomp() -> None:
     assert convert_to_markdown(" <b>  s  </b> ") == " **s** "
 
 
-def test_nested(convert: Callable[[str, ...], str]) -> None:
+def test_nested(convert: Callable[..., str]) -> None:
     text = convert('<p>This is an <a href="http://example.com/">example link</a>.</p>')
     assert text == "This is an [example link](http://example.com/).\n\n"
 
 
-def test_ignore_comments(convert: Callable[[str, ...], str]) -> None:
+def test_ignore_comments(convert: Callable[..., str]) -> None:
     text = convert("<!-- This is a comment -->")
     assert text == ""
 
 
-def test_ignore_comments_with_other_tags(convert: Callable[[str, ...], str]) -> None:
+def test_ignore_comments_with_other_tags(convert: Callable[..., str]) -> None:
     text = convert("<!-- This is a comment --><a href='http://example.com/'>example link</a>")
     assert text == "[example link](http://example.com/)"
 
 
-def test_code_with_tricky_content(convert: Callable[[str, ...], str]) -> None:
+def test_code_with_tricky_content(convert: Callable[..., str]) -> None:
     assert convert("<code>></code>") == "`>`"
     assert convert("<code>/home/</code><b>username</b>") == "`/home/`**username**"
     assert (
@@ -103,33 +103,33 @@ def test_code_with_tricky_content(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_special_tags(convert: Callable[[str, ...], str]) -> None:
+def test_special_tags(convert: Callable[..., str]) -> None:
     assert convert("<!DOCTYPE html>") == ""
 
     assert convert("<![CDATA[foobar]]>") == ""
 
 
-def test_strip(convert: Callable[[str, ...], str]) -> None:
+def test_strip(convert: Callable[..., str]) -> None:
     text = convert('<a href="https://github.com/matthewwithanm">Some Text</a>', strip=["a"])
     assert text == "Some Text"
 
 
-def test_do_not_strip(convert: Callable[[str, ...], str]) -> None:
+def test_do_not_strip(convert: Callable[..., str]) -> None:
     text = convert('<a href="https://github.com/matthewwithanm">Some Text</a>', strip=[])
     assert text == "[Some Text](https://github.com/matthewwithanm)"
 
 
-def test_convert(convert: Callable[[str, ...], str]) -> None:
+def test_convert(convert: Callable[..., str]) -> None:
     text = convert('<a href="https://github.com/matthewwithanm">Some Text</a>', convert=["a"])
     assert text == "[Some Text](https://github.com/matthewwithanm)"
 
 
-def test_do_not_convert(convert: Callable[[str, ...], str]) -> None:
+def test_do_not_convert(convert: Callable[..., str]) -> None:
     text = convert('<a href="https://github.com/matthewwithanm">Some Text</a>', convert=[])
     assert text == "Some Text"
 
 
-def test_ol(convert: Callable[[str, ...], str]) -> None:
+def test_ol(convert: Callable[..., str]) -> None:
     assert convert("<ol><li>a</li><li>b</li></ol>") == "1. a\n2. b\n"
     assert convert('<ol start="3"><li>a</li><li>b</li></ol>') == "3. a\n4. b\n"
     assert convert('<ol start="-1"><li>a</li><li>b</li></ol>') == "1. a\n2. b\n"
@@ -137,14 +137,14 @@ def test_ol(convert: Callable[[str, ...], str]) -> None:
     assert convert('<ol start="1.5"><li>a</li><li>b</li></ol>') == "1. a\n2. b\n"
 
 
-def test_nested_ols(nested_ols: str, convert: Callable[[str, ...], str]) -> None:
+def test_nested_ols(nested_ols: str, convert: Callable[..., str]) -> None:
     assert (
         convert(nested_ols)
         == "1. 1\n\n    1. a\n            1. I\n                2. II\n                3. III\n        2. b\n        3. c\n2. 2\n3. 3\n\n"
     )
 
 
-def test_ul(convert: Callable[[str, ...], str]) -> None:
+def test_ul(convert: Callable[..., str]) -> None:
     assert convert("<ul><li>a</li><li>b</li></ul>") == "* a\n* b\n"
     assert (
         convert(
@@ -161,25 +161,25 @@ def test_ul(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_inline_ul(convert: Callable[[str, ...], str]) -> None:
+def test_inline_ul(convert: Callable[..., str]) -> None:
     assert convert("<p>foo</p><ul><li>a</li><li>b</li></ul><p>bar</p>") == "foo\n\n* a\n* b\n\nbar\n\n"
 
 
-def test_nested_uls(nested_uls: str, convert: Callable[[str, ...], str]) -> None:
+def test_nested_uls(nested_uls: str, convert: Callable[..., str]) -> None:
     assert (
         convert(nested_uls)
         == "* 1\n\n    + a\n            - I\n                - II\n                - III\n        + b\n        + c\n* 2\n* 3\n\n"
     )
 
 
-def test_bullets(nested_uls: str, convert: Callable[[str, ...], str]) -> None:
+def test_bullets(nested_uls: str, convert: Callable[..., str]) -> None:
     assert (
         convert(nested_uls, bullets="-")
         == "- 1\n\n    - a\n            - I\n                - II\n                - III\n        - b\n        - c\n- 2\n- 3\n\n"
     )
 
 
-def test_li_text(convert: Callable[[str, ...], str]) -> None:
+def test_li_text(convert: Callable[..., str]) -> None:
     assert (
         convert('<ul><li>foo <a href="#">bar</a></li><li>foo bar  </li><li>foo <b>bar</b>   <i>space</i>.</ul>')
         == "* foo [bar](#)\n* foo bar\n* foo **bar** *space*.\n"
@@ -200,7 +200,7 @@ def test_table(
     table_with_caption: str,
     table_with_colspan: str,
     table_with_undefined_colspan: str,
-    convert: Callable[[str, ...], str],
+    convert: Callable[..., str],
 ) -> None:
     assert (
         convert(table)
@@ -250,7 +250,7 @@ def test_table(
     assert convert(table_with_undefined_colspan) == "\n\n| Name | Age |\n| --- | --- |\n| Jill | Smith |\n\n"
 
 
-def inline_tests(tag: str, markup: str, convert: Callable[[str, ...], str]) -> None:
+def inline_tests(tag: str, markup: str, convert: Callable[..., str]) -> None:
     assert convert(f"<{tag}>Hello</{tag}>") == f"{markup}Hello{markup}"
     assert convert(f"foo <{tag}>Hello</{tag}> bar") == f"foo {markup}Hello{markup} bar"
     assert convert(f"foo<{tag}> Hello</{tag}> bar") == f"foo {markup}Hello{markup} bar"
@@ -261,7 +261,7 @@ def inline_tests(tag: str, markup: str, convert: Callable[[str, ...], str]) -> N
     ]
 
 
-def test_a(convert: Callable[[str, ...], str]) -> None:
+def test_a(convert: Callable[..., str]) -> None:
     assert convert('<a href="https://google.com">Google</a>') == "[Google](https://google.com)"
     assert convert('<a href="https://google.com">https://google.com</a>') == "<https://google.com>"
     assert (
@@ -277,14 +277,14 @@ def test_a(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_a_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_a_spaces(convert: Callable[..., str]) -> None:
     assert convert('foo <a href="http://google.com">Google</a> bar') == "foo [Google](http://google.com) bar"
     assert convert('foo<a href="http://google.com"> Google</a> bar') == "foo [Google](http://google.com) bar"
     assert convert('foo <a href="http://google.com">Google </a>bar') == "foo [Google](http://google.com) bar"
     assert convert('foo <a href="http://google.com"></a> bar') == "foo  bar"
 
 
-def test_a_with_title(convert: Callable[[str, ...], str]) -> None:
+def test_a_with_title(convert: Callable[..., str]) -> None:
     text = convert('<a href="http://google.com" title="The &quot;Goog&quot;">Google</a>')
     assert text == r'[Google](http://google.com "The \"Goog\"")'
     assert (
@@ -293,54 +293,54 @@ def test_a_with_title(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_a_shortcut(convert: Callable[[str, ...], str]) -> None:
+def test_a_shortcut(convert: Callable[..., str]) -> None:
     text = convert('<a href="http://google.com">http://google.com</a>')
     assert text == "<http://google.com>"
 
 
-def test_a_no_autolinks(convert: Callable[[str, ...], str]) -> None:
+def test_a_no_autolinks(convert: Callable[..., str]) -> None:
     assert (
         convert('<a href="https://google.com">https://google.com</a>', autolinks=False)
         == "[https://google.com](https://google.com)"
     )
 
 
-def test_b(convert: Callable[[str, ...], str]) -> None:
+def test_b(convert: Callable[..., str]) -> None:
     assert convert("<b>Hello</b>") == "**Hello**"
 
 
-def test_b_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_b_spaces(convert: Callable[..., str]) -> None:
     assert convert("foo <b>Hello</b> bar") == "foo **Hello** bar"
     assert convert("foo<b> Hello</b> bar") == "foo **Hello** bar"
     assert convert("foo <b>Hello </b>bar") == "foo **Hello** bar"
     assert convert("foo <b></b> bar") == "foo  bar"
 
 
-def test_blockquote(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote(convert: Callable[..., str]) -> None:
     assert convert("<blockquote>Hello</blockquote>") == "\n> Hello\n\n"
     assert convert("<blockquote>\nHello\n</blockquote>") == "\n> Hello\n\n"
 
 
-def test_blockquote_with_nested_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_with_nested_paragraph(convert: Callable[..., str]) -> None:
     assert convert("<blockquote><p>Hello</p></blockquote>") == "\n> Hello\n\n"
     assert convert("<blockquote><p>Hello</p><p>Hello again</p></blockquote>") == "\n> Hello\n> \n> Hello again\n\n"
 
 
-def test_blockquote_with_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_with_paragraph(convert: Callable[..., str]) -> None:
     assert convert("<blockquote>Hello</blockquote><p>handsome</p>") == "\n> Hello\n\nhandsome\n\n"
 
 
-def test_blockquote_nested(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_nested(convert: Callable[..., str]) -> None:
     text = convert("<blockquote>And she was like <blockquote>Hello</blockquote></blockquote>")
     assert text == "\n> And she was like \n> \n> \n> > Hello\n\n"
 
 
-def test_br(convert: Callable[[str, ...], str]) -> None:
+def test_br(convert: Callable[..., str]) -> None:
     assert convert("a<br />b<br />c") == "a  \nb  \nc"
     assert convert("a<br />b<br />c", newline_style=BACKSLASH) == "a\\\nb\\\nc"
 
 
-def test_caption(convert: Callable[[str, ...], str]) -> None:
+def test_caption(convert: Callable[..., str]) -> None:
     assert (
         convert("TEXT<figure><figcaption>Caption</figcaption><span>SPAN</span></figure>")
         == "TEXT\n\n*Caption*\n\nSPAN\n\n"
@@ -350,12 +350,15 @@ def test_caption(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_code(convert: Callable[[str, ...], str]) -> None:
+def test_code(convert: Callable[..., str]) -> None:
     inline_tests("code", "`", convert)
     assert convert("<code>*this_should_not_escape*</code>") == "`*this_should_not_escape*`"
     assert convert("<kbd>*this_should_not_escape*</kbd>") == "`*this_should_not_escape*`"
     assert convert("<samp>*this_should_not_escape*</samp>") == "`*this_should_not_escape*`"
     assert convert("<code><span>*this_should_not_escape*</span></code>") == "`*this_should_not_escape*`"
+    assert convert("<div><code>code_with_underscores</code></div>") == "`code_with_underscores`\n\n"
+    assert convert("<span><code>*asterisks* and _underscores_</code></span>") == "`*asterisks* and _underscores_`"
+    assert convert("<p><code>foo_bar_baz</code></p>") == "`foo_bar_baz`\n\n"
     assert convert("<code>this  should\t\tnormalize</code>") == "`this should normalize`"
     assert convert("<code><span>this  should\t\tnormalize</span></code>") == "`this should normalize`"
     assert convert("<code>foo<b>bar</b>baz</code>") == "`foobarbaz`"
@@ -370,19 +373,19 @@ def test_code(convert: Callable[[str, ...], str]) -> None:
     assert convert("<code>foo<sub>bar</sub>baz</code>") == "`foobarbaz`"
 
 
-def test_del(convert: Callable[[str, ...], str]) -> None:
+def test_del(convert: Callable[..., str]) -> None:
     inline_tests("del", "~~", convert)
 
 
-def test_div(convert: Callable[[str, ...], str]) -> None:
+def test_div(convert: Callable[..., str]) -> None:
     assert convert("Hello</div> World") == "Hello World"
 
 
-def test_em(convert: Callable[[str, ...], str]) -> None:
+def test_em(convert: Callable[..., str]) -> None:
     inline_tests("em", "*", convert)
 
 
-def test_header_with_space(convert: Callable[[str, ...], str]) -> None:
+def test_header_with_space(convert: Callable[..., str]) -> None:
     assert convert("<h3>\n\nHello</h3>") == "### Hello\n\n"
     assert convert("<h4>\n\nHello</h4>") == "#### Hello\n\n"
     assert convert("<h5>\n\nHello</h5>") == "##### Hello\n\n"
@@ -390,22 +393,22 @@ def test_header_with_space(convert: Callable[[str, ...], str]) -> None:
     assert convert("<h5>\n\nHello   \n\n</h5>") == "##### Hello\n\n"
 
 
-def test_h1(convert: Callable[[str, ...], str]) -> None:
+def test_h1(convert: Callable[..., str]) -> None:
     assert convert("<h1>Hello</h1>") == "Hello\n=====\n\n"
 
 
-def test_h2(convert: Callable[[str, ...], str]) -> None:
+def test_h2(convert: Callable[..., str]) -> None:
     assert convert("<h2>Hello</h2>") == "Hello\n-----\n\n"
 
 
-def test_hn(convert: Callable[[str, ...], str]) -> None:
+def test_hn(convert: Callable[..., str]) -> None:
     assert convert("<h3>Hello</h3>") == "### Hello\n\n"
     assert convert("<h4>Hello</h4>") == "#### Hello\n\n"
     assert convert("<h5>Hello</h5>") == "##### Hello\n\n"
     assert convert("<h6>Hello</h6>") == "###### Hello\n\n"
 
 
-def test_hn_chained(convert: Callable[[str, ...], str]) -> None:
+def test_hn_chained(convert: Callable[..., str]) -> None:
     assert (
         convert("<h1>First</h1>\n<h2>Second</h2>\n<h3>Third</h3>", heading_style=ATX)
         == "# First\n\n## Second\n\n### Third\n\n"
@@ -413,7 +416,7 @@ def test_hn_chained(convert: Callable[[str, ...], str]) -> None:
     assert convert("X<h1>First</h1>", heading_style=ATX) == "X\n\n# First\n\n"
 
 
-def test_hn_nested_tag_heading_style(convert: Callable[[str, ...], str]) -> None:
+def test_hn_nested_tag_heading_style(convert: Callable[..., str]) -> None:
     result = convert("<h1>A <p>P</p> C </h1>", heading_style=ATX_CLOSED)
     assert result in ["# A P C #\n\n", "# A #\n\nP\n\n C "]
 
@@ -421,7 +424,7 @@ def test_hn_nested_tag_heading_style(convert: Callable[[str, ...], str]) -> None
     assert result2 in ["# A P C\n\n", "# A\n\nP\n\n C "]
 
 
-def test_hn_eol(convert: Callable[[str, ...], str]) -> None:
+def test_hn_eol(convert: Callable[..., str]) -> None:
     assert convert("<p>xxx</p><h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
 
     assert convert("\n<h3>Hello</h3>", heading_style=ATX) == "### Hello\n\n"
@@ -430,7 +433,7 @@ def test_hn_eol(convert: Callable[[str, ...], str]) -> None:
     assert convert("xxx<h3>Hello</h3>", heading_style=ATX) == "xxx\n\n### Hello\n\n"
 
 
-def test_hn_nested_simple_tag(convert: Callable[[str, ...], str]) -> None:
+def test_hn_nested_simple_tag(convert: Callable[..., str]) -> None:
     inline_tag_to_markdown = [
         ("strong", "**strong**"),
         ("b", "**b**"),
@@ -450,7 +453,7 @@ def test_hn_nested_simple_tag(convert: Callable[[str, ...], str]) -> None:
     assert convert("<h3>A <br>B</h3>", heading_style=ATX) == "### A  B\n\n"
 
 
-def test_hn_nested_img(convert: Callable[[str, ...], str]) -> None:
+def test_hn_nested_img(convert: Callable[..., str]) -> None:
     image_attributes_to_markdown = [
         ("", "", ""),
         ("alt='Alt Text'", "Alt Text", ""),
@@ -470,31 +473,31 @@ def test_hn_nested_img(convert: Callable[[str, ...], str]) -> None:
         )
 
 
-def test_hn_atx_headings(convert: Callable[[str, ...], str]) -> None:
+def test_hn_atx_headings(convert: Callable[..., str]) -> None:
     assert convert("<h1>Hello</h1>", heading_style=ATX) == "# Hello\n\n"
     assert convert("<h2>Hello</h2>", heading_style=ATX) == "## Hello\n\n"
 
 
-def test_hn_atx_closed_headings(convert: Callable[[str, ...], str]) -> None:
+def test_hn_atx_closed_headings(convert: Callable[..., str]) -> None:
     assert convert("<h1>Hello</h1>", heading_style=ATX_CLOSED) == "# Hello #\n\n"
     assert convert("<h2>Hello</h2>", heading_style=ATX_CLOSED) == "## Hello ##\n\n"
 
 
-def test_head(convert: Callable[[str, ...], str]) -> None:
+def test_head(convert: Callable[..., str]) -> None:
     assert convert("<head>head</head>") == "head"
 
 
-def test_hr(convert: Callable[[str, ...], str]) -> None:
+def test_hr(convert: Callable[..., str]) -> None:
     assert convert("Hello<hr>World") == "Hello\n\n---\n\nWorld"
     assert convert("Hello<hr />World") == "Hello\n\n---\n\nWorld"
     assert convert("<p>Hello</p>\n<hr>\n<p>World</p>") == "Hello\n\n---\n\nWorld\n\n"
 
 
-def test_i(convert: Callable[[str, ...], str]) -> None:
+def test_i(convert: Callable[..., str]) -> None:
     assert convert("<i>Hello</i>") == "*Hello*"
 
 
-def test_img(convert: Callable[[str, ...], str]) -> None:
+def test_img(convert: Callable[..., str]) -> None:
     assert (
         convert('<img src="/path/to/img.jpg" alt="Alt text" title="Optional title" />')
         == '![Alt text](/path/to/img.jpg "Optional title")'
@@ -506,11 +509,11 @@ def test_img(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_kbd(convert: Callable[[str, ...], str]) -> None:
+def test_kbd(convert: Callable[..., str]) -> None:
     inline_tests("kbd", "`", convert)
 
 
-def test_p(convert: Callable[[str, ...], str]) -> None:
+def test_p(convert: Callable[..., str]) -> None:
     assert convert("<p>hello</p>") == "hello\n\n"
     assert convert("<p>123456789 123456789</p>") == "123456789 123456789\n\n"
     assert convert("<p>123456789 123456789</p>", wrap=True, wrap_width=10) == "123456789\n123456789\n\n"
@@ -534,13 +537,13 @@ def test_p(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_mark_tag(convert: Callable[[str, ...], str]) -> None:
+def test_mark_tag(convert: Callable[..., str]) -> None:
     html = "<mark>highlighted</mark>"
     expected = "==highlighted=="
     assert convert(html).strip() == expected
 
 
-def test_mark_tag_with_different_styles(convert: Callable[[str, ...], str]) -> None:
+def test_mark_tag_with_different_styles(convert: Callable[..., str]) -> None:
     html = "<mark>highlighted</mark>"
 
     assert convert(html, highlight_style="double-equal").strip() == "==highlighted=="
@@ -550,13 +553,13 @@ def test_mark_tag_with_different_styles(convert: Callable[[str, ...], str]) -> N
     assert convert(html, highlight_style="html").strip() == "<mark>highlighted</mark>"
 
 
-def test_mark_tag_in_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_mark_tag_in_paragraph(convert: Callable[..., str]) -> None:
     html = "<p>This is <mark>highlighted text</mark> in a paragraph.</p>"
     expected = "This is ==highlighted text== in a paragraph.\n\n"
     assert convert(html) == expected
 
 
-def test_mark_tag_with_nested_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_mark_tag_with_nested_formatting(convert: Callable[..., str]) -> None:
     html = "<mark>This is <strong>bold highlighted</strong> text</mark>"
     expected = "==This is **bold highlighted** text=="
     assert convert(html).strip() == expected
@@ -566,25 +569,25 @@ def test_mark_tag_with_nested_formatting(convert: Callable[[str, ...], str]) -> 
     assert convert(html).strip() == expected
 
 
-def test_multiple_mark_tags(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_mark_tags(convert: Callable[..., str]) -> None:
     html = "<p>First <mark>highlight</mark> and second <mark>highlight</mark>.</p>"
     expected = "First ==highlight== and second ==highlight==.\n\n"
     assert convert(html) == expected
 
 
-def test_nested_mark_tags(convert: Callable[[str, ...], str]) -> None:
+def test_nested_mark_tags(convert: Callable[..., str]) -> None:
     html = "<mark>Outer <mark>nested</mark> mark</mark>"
     expected = "==Outer ==nested== mark=="
     assert convert(html).strip() == expected
 
 
-def test_mark_tag_as_inline(convert: Callable[[str, ...], str]) -> None:
+def test_mark_tag_as_inline(convert: Callable[..., str]) -> None:
     html = "<mark>highlighted</mark>"
     expected = "highlighted"
     assert convert(html, convert_as_inline=True).strip() == expected
 
 
-def test_mark_tag_with_complex_content(convert: Callable[[str, ...], str]) -> None:
+def test_mark_tag_with_complex_content(convert: Callable[..., str]) -> None:
     html = """
     <div>
         <h2>Title</h2>
@@ -600,11 +603,16 @@ def test_mark_tag_with_complex_content(convert: Callable[[str, ...], str]) -> No
     assert "==highlighted item text==" in result
 
 
-def test_pre(convert: Callable[[str, ...], str]) -> None:
+def test_pre(convert: Callable[..., str]) -> None:
     assert convert("<pre>test\n    foo\nbar</pre>") == "\n```\ntest\n    foo\nbar\n```\n"
     assert convert("<pre><code>test\n    foo\nbar</code></pre>") == "\n```\ntest\n    foo\nbar\n```\n"
     assert convert("<pre>*this_should_not_escape*</pre>") == "\n```\n*this_should_not_escape*\n```\n"
     assert convert("<pre><span>*this_should_not_escape*</span></pre>") == "\n```\n*this_should_not_escape*\n```\n"
+    assert convert("<div><pre>code_with_underscores</pre></div>") == "```\ncode_with_underscores\n```\n\n"
+    assert (
+        convert("<div><pre>*asterisks* and _underscores_</pre></div>") == "```\n*asterisks* and _underscores_\n```\n\n"
+    )
+    assert convert("<section><pre>foo_bar_baz</pre></section>") == "\n```\nfoo_bar_baz\n```\n\n"
     assert (
         convert("<pre>\t\tthis  should\t\tnot  normalize</pre>") == "\n```\n\t\tthis  should\t\tnot  normalize\n```\n"
     )
@@ -625,46 +633,46 @@ def test_pre(convert: Callable[[str, ...], str]) -> None:
     assert convert("<pre>foo<sub>\nbar\n</sub>baz</pre>", sub_symbol="^") == "\n```\nfoo\nbar\nbaz\n```\n"
 
 
-def test_script(convert: Callable[[str, ...], str]) -> None:
+def test_script(convert: Callable[..., str]) -> None:
     assert convert("foo <script>var foo=42;</script> bar") == "foo  bar"
 
 
-def test_style(convert: Callable[[str, ...], str]) -> None:
+def test_style(convert: Callable[..., str]) -> None:
     assert convert("foo <style>h1 { font-size: larger }</style> bar") == "foo  bar"
 
 
-def test_s(convert: Callable[[str, ...], str]) -> None:
+def test_s(convert: Callable[..., str]) -> None:
     inline_tests("s", "~~", convert)
 
 
-def test_samp(convert: Callable[[str, ...], str]) -> None:
+def test_samp(convert: Callable[..., str]) -> None:
     inline_tests("samp", "`", convert)
 
 
-def test_strong(convert: Callable[[str, ...], str]) -> None:
+def test_strong(convert: Callable[..., str]) -> None:
     assert convert("<strong>Hello</strong>") == "**Hello**"
 
 
-def test_strong_em_symbol(convert: Callable[[str, ...], str]) -> None:
+def test_strong_em_symbol(convert: Callable[..., str]) -> None:
     assert convert("<strong>Hello</strong>", strong_em_symbol=UNDERSCORE) == "__Hello__"
     assert convert("<b>Hello</b>", strong_em_symbol=UNDERSCORE) == "__Hello__"
     assert convert("<em>Hello</em>", strong_em_symbol=UNDERSCORE) == "_Hello_"
     assert convert("<i>Hello</i>", strong_em_symbol=UNDERSCORE) == "_Hello_"
 
 
-def test_sub(convert: Callable[[str, ...], str]) -> None:
+def test_sub(convert: Callable[..., str]) -> None:
     assert convert("<sub>foo</sub>") == "foo"
     assert convert("<sub>foo</sub>", sub_symbol="~") == "~foo~"
     assert convert("<sub>foo</sub>", sub_symbol="<sub>") == "<sub>foo</sub>"
 
 
-def test_sup(convert: Callable[[str, ...], str]) -> None:
+def test_sup(convert: Callable[..., str]) -> None:
     assert convert("<sup>foo</sup>") == "foo"
     assert convert("<sup>foo</sup>", sup_symbol="^") == "^foo^"
     assert convert("<sup>foo</sup>", sup_symbol="<sup>") == "<sup>foo</sup>"
 
 
-def test_lang(convert: Callable[[str, ...], str]) -> None:
+def test_lang(convert: Callable[..., str]) -> None:
     assert convert("<pre>test\n    foo\nbar</pre>", code_language="python") == "\n```python\ntest\n    foo\nbar\n```\n"
     assert (
         convert("<pre><code>test\n    foo\nbar</code></pre>", code_language="javascript")
@@ -672,7 +680,7 @@ def test_lang(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_lang_callback(convert: Callable[[str, ...], str]) -> None:
+def test_lang_callback(convert: Callable[..., str]) -> None:
     def callback(el: Tag) -> str | None:
         return el["class"][0] if el.has_attr("class") else None
 
@@ -699,13 +707,13 @@ def test_lang_callback(convert: Callable[[str, ...], str]) -> None:
     )
 
 
-def test_idempotence(convert: Callable[[str, ...], str]) -> None:
+def test_idempotence(convert: Callable[..., str]) -> None:
     html_text = "<h2>Header&nbsp;</h2><p>Next paragraph.</p>"
     converted = convert(html_text)
     assert converted == convert(converted)
 
 
-def test_character_encoding(convert: Callable[[str, ...], str]) -> None:
+def test_character_encoding(convert: Callable[..., str]) -> None:
     html_with_encoding_issue = (
         "<cite>api_key=”your-api-key”</cite> or by defining <cite>GOOGLE_API_KEY=”your-api-key”</cite> as an"
     )

--- a/tests/interactive_elements_test.py
+++ b/tests/interactive_elements_test.py
@@ -6,57 +6,57 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def test_dialog_basic(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_basic(convert: Callable[..., str]) -> None:
     """Test basic dialog conversion."""
     html = "<dialog>Simple dialog content</dialog>"
     result = convert(html)
     assert result == "Simple dialog content\n\n"
 
 
-def test_dialog_open(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_open(convert: Callable[..., str]) -> None:
     html = "<dialog open>This dialog is open</dialog>"
     result = convert(html)
     assert result == "This dialog is open\n\n"
 
 
-def test_dialog_with_id(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_with_id(convert: Callable[..., str]) -> None:
     html = '<dialog id="myDialog">Dialog with ID</dialog>'
     result = convert(html)
     assert result == "Dialog with ID\n\n"
 
 
-def test_dialog_open_with_id(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_open_with_id(convert: Callable[..., str]) -> None:
     html = '<dialog open id="openDialog">Open dialog with ID</dialog>'
     result = convert(html)
     assert result == "Open dialog with ID\n\n"
 
 
-def test_dialog_empty(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_empty(convert: Callable[..., str]) -> None:
     html = "<dialog></dialog>"
     result = convert(html)
     assert result == ""
 
 
-def test_dialog_whitespace_only(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_whitespace_only(convert: Callable[..., str]) -> None:
     html = "<dialog>   \n  \t  </dialog>"
     result = convert(html)
     assert result == ""
 
 
-def test_dialog_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_inline_mode(convert: Callable[..., str]) -> None:
     html = "<dialog>Inline dialog content</dialog>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline dialog content"
 
 
-def test_dialog_with_nested_elements(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_with_nested_elements(convert: Callable[..., str]) -> None:
     html = "<dialog><h2>Dialog Title</h2><p>Dialog content with <strong>bold</strong> text.</p></dialog>"
     result = convert(html)
     expected = """Dialog Title\n------------\n\nDialog content with **bold** text.\n\n"""
     assert result == expected
 
 
-def test_dialog_multiline_content(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_multiline_content(convert: Callable[..., str]) -> None:
     html = """<dialog>
         <p>First paragraph</p>
         <p>Second paragraph</p>
@@ -66,7 +66,7 @@ def test_dialog_multiline_content(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_dialog_with_buttons(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_with_buttons(convert: Callable[..., str]) -> None:
     html = """<dialog>
         <p>Are you sure?</p>
         <button>Yes</button>
@@ -77,80 +77,80 @@ def test_dialog_with_buttons(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_menu_basic(convert: Callable[[str, ...], str]) -> None:
+def test_menu_basic(convert: Callable[..., str]) -> None:
     html = "<menu><li>Item 1</li><li>Item 2</li></menu>"
     result = convert(html)
     assert result == "- Item 1\n- Item 2\n\n"
 
 
-def test_menu_toolbar(convert: Callable[[str, ...], str]) -> None:
+def test_menu_toolbar(convert: Callable[..., str]) -> None:
     html = '<menu type="toolbar"><li>Cut</li><li>Copy</li><li>Paste</li></menu>'
     result = convert(html)
     assert result == "- Cut\n- Copy\n- Paste\n\n"
 
 
-def test_menu_context(convert: Callable[[str, ...], str]) -> None:
+def test_menu_context(convert: Callable[..., str]) -> None:
     html = '<menu type="context"><li>Delete</li><li>Rename</li></menu>'
     result = convert(html)
     assert result == "- Delete\n- Rename\n\n"
 
 
-def test_menu_with_label(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_label(convert: Callable[..., str]) -> None:
     html = '<menu label="File Operations"><li>Open</li><li>Save</li></menu>'
     result = convert(html)
     assert result == "- Open\n- Save\n\n"
 
 
-def test_menu_toolbar_with_label(convert: Callable[[str, ...], str]) -> None:
+def test_menu_toolbar_with_label(convert: Callable[..., str]) -> None:
     html = '<menu type="toolbar" label="Edit Tools"><li>Bold</li><li>Italic</li></menu>'
     result = convert(html)
     assert result == "- Bold\n- Italic\n\n"
 
 
-def test_menu_with_id(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_id(convert: Callable[..., str]) -> None:
     html = '<menu id="mainMenu"><li>Home</li><li>About</li></menu>'
     result = convert(html)
     assert result == "- Home\n- About\n\n"
 
 
-def test_menu_all_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_menu_all_attributes(convert: Callable[..., str]) -> None:
     html = '<menu type="context" label="Context Actions" id="contextMenu"><li>Edit</li><li>Delete</li></menu>'
     result = convert(html)
     assert result == "- Edit\n- Delete\n\n"
 
 
-def test_menu_type_list_omitted(convert: Callable[[str, ...], str]) -> None:
+def test_menu_type_list_omitted(convert: Callable[..., str]) -> None:
     html = '<menu type="list"><li>Item 1</li><li>Item 2</li></menu>'
     result = convert(html)
     assert result == "- Item 1\n- Item 2\n\n"
 
 
-def test_menu_empty(convert: Callable[[str, ...], str]) -> None:
+def test_menu_empty(convert: Callable[..., str]) -> None:
     html = "<menu></menu>"
     result = convert(html)
     assert result == ""
 
 
-def test_menu_whitespace_only(convert: Callable[[str, ...], str]) -> None:
+def test_menu_whitespace_only(convert: Callable[..., str]) -> None:
     html = "<menu>   \n  \t  </menu>"
     result = convert(html)
     assert result == ""
 
 
-def test_menu_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_menu_inline_mode(convert: Callable[..., str]) -> None:
     html = "<menu><li>Inline item</li></menu>"
     result = convert(html, convert_as_inline=True)
     assert result == "- Inline item"
 
 
-def test_menu_with_nested_elements(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_nested_elements(convert: Callable[..., str]) -> None:
     html = "<menu><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></menu>"
     result = convert(html)
     expected = "- **Bold Item**\n- *Italic Item*\n\n"
     assert result == expected
 
 
-def test_menu_with_buttons(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_buttons(convert: Callable[..., str]) -> None:
     html = """<menu type="toolbar">
         <button>New</button>
         <button>Open</button>
@@ -161,7 +161,7 @@ def test_menu_with_buttons(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_menu_mixed_content(convert: Callable[[str, ...], str]) -> None:
+def test_menu_mixed_content(convert: Callable[..., str]) -> None:
     html = """<menu>
         <li>List item</li>
         <button>Button item</button>
@@ -172,14 +172,14 @@ def test_menu_mixed_content(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_dialog_in_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_in_paragraph(convert: Callable[..., str]) -> None:
     html = "<p>Click here: <dialog>Modal content</dialog> to see dialog.</p>"
     result = convert(html)
     expected = "Click here: Modal content\n\n to see dialog.\n\n"
     assert result == expected
 
 
-def test_menu_in_navigation(convert: Callable[[str, ...], str]) -> None:
+def test_menu_in_navigation(convert: Callable[..., str]) -> None:
     html = """<nav>
         <menu>
             <li><a href="/home">Home</a></li>
@@ -191,7 +191,7 @@ def test_menu_in_navigation(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_nested_interactive_elements(convert: Callable[[str, ...], str]) -> None:
+def test_nested_interactive_elements(convert: Callable[..., str]) -> None:
     html = """<div>
         <details>
             <summary>Show Menu</summary>
@@ -206,7 +206,7 @@ def test_nested_interactive_elements(convert: Callable[[str, ...], str]) -> None
     assert result == expected
 
 
-def test_dialog_with_form(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_with_form(convert: Callable[..., str]) -> None:
     html = """<dialog open>
         <form>
             <label>Name: <input type="text" name="name"></label>
@@ -218,7 +218,7 @@ def test_dialog_with_form(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_multiple_dialogs(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_dialogs(convert: Callable[..., str]) -> None:
     html = """
     <dialog id="dialog1">First dialog</dialog>
     <dialog id="dialog2" open>Second dialog</dialog>
@@ -228,7 +228,7 @@ def test_multiple_dialogs(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_menu_with_submenus(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_submenus(convert: Callable[..., str]) -> None:
     html = """<menu>
         <li>File
             <menu>
@@ -243,45 +243,45 @@ def test_menu_with_submenus(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_dialog_with_special_characters(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_with_special_characters(convert: Callable[..., str]) -> None:
     html = "<dialog>This has *asterisks* and _underscores_ and [brackets]</dialog>"
     result = convert(html)
     expected = "This has \\*asterisks\\* and \\_underscores\\_ and \\[brackets]\n\n"
     assert result == expected
 
 
-def test_menu_with_special_characters(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_special_characters(convert: Callable[..., str]) -> None:
     html = "<menu><li>Item with *bold* text</li><li>Item with _italic_ text</li></menu>"
     result = convert(html)
     expected = "- Item with \\*bold\\* text\n- Item with \\_italic\\_ text\n\n"
     assert result == expected
 
 
-def test_dialog_attribute_values_with_quotes(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_attribute_values_with_quotes(convert: Callable[..., str]) -> None:
     html = '<dialog id="my-dialog" class="special">Content</dialog>'
     result = convert(html)
     assert result == "Content\n\n"
 
 
-def test_dialog_content_ending_with_single_newline(convert: Callable[[str, ...], str]) -> None:
+def test_dialog_content_ending_with_single_newline(convert: Callable[..., str]) -> None:
     html = "<dialog>Content\n</dialog>"
     result = convert(html)
     assert result == "Content\n\n"
 
 
-def test_menu_with_complex_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_menu_with_complex_attributes(convert: Callable[..., str]) -> None:
     html = '<menu type="toolbar" label="Tools &amp; Options" id="toolbar-1"><li>Cut</li></menu>'
     result = convert(html)
     assert result == "- Cut\n\n"
 
 
-def test_empty_dialog_with_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_empty_dialog_with_attributes(convert: Callable[..., str]) -> None:
     html = '<dialog open id="empty"></dialog>'
     result = convert(html)
     assert result == ""
 
 
-def test_empty_menu_with_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_empty_menu_with_attributes(convert: Callable[..., str]) -> None:
     html = '<menu type="toolbar" label="Empty"></menu>'
     result = convert(html)
     assert result == ""

--- a/tests/list_indent_test.py
+++ b/tests/list_indent_test.py
@@ -8,32 +8,32 @@ if TYPE_CHECKING:
 import pytest
 
 
-def test_default_list_indent_4_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_default_list_indent_4_spaces(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested item</li></ul></li></ul>"
     result = convert(html)
     assert "    + Nested item" in result
 
 
-def test_custom_spaces_indent_2_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_custom_spaces_indent_2_spaces(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested item</li></ul></li></ul>"
     result = convert(html, list_indent_width=2, list_indent_type="spaces")
     assert "  + Nested item" in result
     assert "    + Nested item" not in result
 
 
-def test_custom_spaces_indent_6_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_custom_spaces_indent_6_spaces(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested item</li></ul></li></ul>"
     result = convert(html, list_indent_width=6, list_indent_type="spaces")
     assert "      + Nested item" in result
 
 
-def test_tabs_indent(convert: Callable[[str, ...], str]) -> None:
+def test_tabs_indent(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested item</li></ul></li></ul>"
     result = convert(html, list_indent_type="tabs")
     assert "\t+ Nested item" in result
 
 
-def test_tabs_ignore_width(convert: Callable[[str, ...], str]) -> None:
+def test_tabs_ignore_width(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested item</li></ul></li></ul>"
     result1 = convert(html, list_indent_type="tabs", list_indent_width=2)
     result2 = convert(html, list_indent_type="tabs", list_indent_width=8)
@@ -41,7 +41,7 @@ def test_tabs_ignore_width(convert: Callable[[str, ...], str]) -> None:
     assert "\t+ Nested item" in result1
 
 
-def test_deeply_nested_lists(convert: Callable[[str, ...], str]) -> None:
+def test_deeply_nested_lists(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li>Level 1
@@ -67,7 +67,7 @@ def test_deeply_nested_lists(convert: Callable[[str, ...], str]) -> None:
     assert "    - Level 3" in level3_line
 
 
-def test_mixed_list_types_with_custom_indent(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_list_types_with_custom_indent(convert: Callable[..., str]) -> None:
     html = """
     <ol>
         <li>First ordered
@@ -82,7 +82,7 @@ def test_mixed_list_types_with_custom_indent(convert: Callable[[str, ...], str])
     assert "   * First unordered" in result
 
 
-def test_blockquote_in_list_with_custom_indent(convert: Callable[[str, ...], str]) -> None:
+def test_blockquote_in_list_with_custom_indent(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li>
@@ -95,7 +95,7 @@ def test_blockquote_in_list_with_custom_indent(convert: Callable[[str, ...], str
     assert "  > This is a quote" in result
 
 
-def test_paragraph_in_list_with_custom_indent(convert: Callable[[str, ...], str]) -> None:
+def test_paragraph_in_list_with_custom_indent(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li>
@@ -114,7 +114,7 @@ def test_paragraph_in_list_with_custom_indent(convert: Callable[[str, ...], str]
     assert "  Second paragraph" in second_para_line
 
 
-def test_code_block_in_list_preserves_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_code_block_in_list_preserves_formatting(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li>Item with code
@@ -128,7 +128,7 @@ def test_code_block_in_list_preserves_formatting(convert: Callable[[str, ...], s
     assert '    print("world")' in result
 
 
-def test_task_list_with_custom_indent(convert: Callable[[str, ...], str]) -> None:
+def test_task_list_with_custom_indent(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li><input type="checkbox" checked> Completed task
@@ -143,7 +143,7 @@ def test_task_list_with_custom_indent(convert: Callable[[str, ...], str]) -> Non
     assert "  - [ ] Subtask" in result
 
 
-def test_backward_compatibility_default_behavior(convert: Callable[[str, ...], str]) -> None:
+def test_backward_compatibility_default_behavior(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item<ul><li>Nested</li></ul></li></ul>"
     result1 = convert(html)
     result2 = convert(html, list_indent_width=4, list_indent_type="spaces")
@@ -152,34 +152,34 @@ def test_backward_compatibility_default_behavior(convert: Callable[[str, ...], s
 
 
 @pytest.mark.parametrize("indent_width", [1, 2, 3, 4, 5, 6, 8])
-def test_various_indent_widths(indent_width: int, convert: Callable[[str, ...], str]) -> None:
+def test_various_indent_widths(indent_width: int, convert: Callable[..., str]) -> None:
     html = "<ul><li>Item<ul><li>Nested</li></ul></li></ul>"
     result = convert(html, list_indent_width=indent_width, list_indent_type="spaces")
     expected_spaces = " " * indent_width
     assert f"{expected_spaces}+ Nested" in result
 
 
-def test_edge_case_zero_width_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_edge_case_zero_width_spaces(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item<ul><li>Nested</li></ul></li></ul>"
     result = convert(html, list_indent_width=0, list_indent_type="spaces")
     assert "+ Nested" in result
     assert " + Nested" not in result
 
 
-def test_very_large_indent_width(convert: Callable[[str, ...], str]) -> None:
+def test_very_large_indent_width(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item<ul><li>Nested</li></ul></li></ul>"
     result = convert(html, list_indent_width=20, list_indent_type="spaces")
     expected_spaces = " " * 20
     assert f"{expected_spaces}+ Nested" in result
 
 
-def test_list_indent_type_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_list_indent_type_spaces(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested Item</li></ul></li></ul>"
     result = convert(html, list_indent_type="spaces", list_indent_width=2)
     assert "  + Nested Item" in result
 
 
-def test_list_indent_type_tabs(convert: Callable[[str, ...], str]) -> None:
+def test_list_indent_type_tabs(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1<ul><li>Nested Item</li></ul></li></ul>"
     result = convert(html, list_indent_type="tabs")
     assert "\t+ Nested Item" in result

--- a/tests/lists_test.py
+++ b/tests/lists_test.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 import pytest
 
 
-def test_basic_unordered_list(convert: Callable[[str, ...], str]) -> None:
+def test_basic_unordered_list(convert: Callable[..., str]) -> None:
     html = """<ul>
     <li>Item 1</li>
     <li>Item 2</li>
@@ -23,7 +23,7 @@ def test_basic_unordered_list(convert: Callable[[str, ...], str]) -> None:
     assert "* Item 3" in result
 
 
-def test_basic_ordered_list(convert: Callable[[str, ...], str]) -> None:
+def test_basic_ordered_list(convert: Callable[..., str]) -> None:
     html = """<ol>
     <li>First</li>
     <li>Second</li>
@@ -36,7 +36,7 @@ def test_basic_ordered_list(convert: Callable[[str, ...], str]) -> None:
     assert "3. Third" in result
 
 
-def test_list_first_item_indent_with_strip_newlines(convert: Callable[[str, ...], str]) -> None:
+def test_list_first_item_indent_with_strip_newlines(convert: Callable[..., str]) -> None:
     html = """
     <p>Above</p>
     <ul>
@@ -56,7 +56,7 @@ def test_list_first_item_indent_with_strip_newlines(convert: Callable[[str, ...]
         assert first_item.startswith("*"), "First item should start with bullet"
 
 
-def test_list_indentation_consistency(convert: Callable[[str, ...], str]) -> None:
+def test_list_indentation_consistency(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li>Item 1</li>
@@ -79,7 +79,7 @@ def test_list_indentation_consistency(convert: Callable[[str, ...], str]) -> Non
                 assert indent == first_indent, f"Inconsistent indentation: {indent} != {first_indent}"
 
 
-def test_list_with_multiple_paragraphs(convert: Callable[[str, ...], str]) -> None:
+def test_list_with_multiple_paragraphs(convert: Callable[..., str]) -> None:
     html = """<ul>
     <li>
         <p>First paragraph</p>
@@ -101,7 +101,7 @@ def test_list_with_multiple_paragraphs(convert: Callable[[str, ...], str]) -> No
             assert line.startswith(("    ", "\t")), "Second paragraph should be indented"
 
 
-def test_list_with_nested_paragraphs_complex(convert: Callable[[str, ...], str]) -> None:
+def test_list_with_nested_paragraphs_complex(convert: Callable[..., str]) -> None:
     html = """<ol>
     <li>
         <p>Item 1 first paragraph</p>
@@ -121,7 +121,7 @@ def test_list_with_nested_paragraphs_complex(convert: Callable[[str, ...], str])
     assert "3. Item 3 with paragraph" in result
 
 
-def test_nested_list_not_inside_li(convert: Callable[[str, ...], str]) -> None:
+def test_nested_list_not_inside_li(convert: Callable[..., str]) -> None:
     html = "<ul><li>a</li><li>b</li><ul><li>c</li><li>d</li></ul></ul>"
 
     result = convert(html)
@@ -130,7 +130,7 @@ def test_nested_list_not_inside_li(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_nested_list_not_inside_li_with_multiple_levels(convert: Callable[[str, ...], str]) -> None:
+def test_nested_list_not_inside_li_with_multiple_levels(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>Item 1</li>
         <li>Item 2</li>
@@ -154,7 +154,7 @@ def test_nested_list_not_inside_li_with_multiple_levels(convert: Callable[[str, 
     assert "* Item 3" in result
 
 
-def test_mixed_correct_and_incorrect_nesting(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_correct_and_incorrect_nesting(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>Item 1
             <ul>
@@ -181,7 +181,7 @@ def test_mixed_correct_and_incorrect_nesting(convert: Callable[[str, ...], str])
     assert "* Item 3" in result
 
 
-def test_ordered_list_incorrectly_nested(convert: Callable[[str, ...], str]) -> None:
+def test_ordered_list_incorrectly_nested(convert: Callable[..., str]) -> None:
     html = "<ol><li>First</li><li>Second</li><ol><li>Nested first</li><li>Nested second</li></ol></ol>"
 
     result = convert(html)
@@ -192,7 +192,7 @@ def test_ordered_list_incorrectly_nested(convert: Callable[[str, ...], str]) -> 
         assert line in result
 
 
-def test_deeply_incorrect_nesting(convert: Callable[[str, ...], str]) -> None:
+def test_deeply_incorrect_nesting(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>Level 1</li>
         <ul>
@@ -214,7 +214,7 @@ def test_deeply_incorrect_nesting(convert: Callable[[str, ...], str]) -> None:
     assert "            * Level 4" in result
 
 
-def test_list_after_paragraph_with_empty_lines(convert: Callable[[str, ...], str]) -> None:
+def test_list_after_paragraph_with_empty_lines(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <p>First paragraph</p>
@@ -233,7 +233,7 @@ def test_list_after_paragraph_with_empty_lines(convert: Callable[[str, ...], str
     assert "Second item" in result
 
 
-def test_nested_list_without_preceding_paragraph(convert: Callable[[str, ...], str]) -> None:
+def test_nested_list_without_preceding_paragraph(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <ul>
@@ -246,7 +246,7 @@ def test_nested_list_without_preceding_paragraph(convert: Callable[[str, ...], s
     assert "Direct nested item" in result
 
 
-def test_empty_line_handling_in_nested_list(convert: Callable[[str, ...], str]) -> None:
+def test_empty_line_handling_in_nested_list(convert: Callable[..., str]) -> None:
     html = """<ul>
         <li>
             <p>Paragraph before</p>
@@ -354,6 +354,6 @@ def test_empty_line_handling_in_nested_list(convert: Callable[[str, ...], str]) 
         ),
     ],
 )
-def test_multiline_list_item_indentation_issues(html: str, expected: str, convert: Callable[[str, ...], str]) -> None:
+def test_multiline_list_item_indentation_issues(html: str, expected: str, convert: Callable[..., str]) -> None:
     result = convert(html)
     assert result == expected

--- a/tests/processing_test.py
+++ b/tests/processing_test.py
@@ -15,31 +15,31 @@ from html_to_markdown.exceptions import ConflictingOptionsError, EmptyHtmlError,
 from html_to_markdown.processing import _as_optional_set, _get_list_indent, convert_to_markdown_stream
 
 
-def test_get_list_indent_tabs(convert: Callable[[str, ...], str]) -> None:
+def test_get_list_indent_tabs(convert: Callable[..., str]) -> None:
     result = _get_list_indent("tabs", 4)
     assert result == "\t"
 
 
-def test_get_list_indent_spaces(convert: Callable[[str, ...], str]) -> None:
+def test_get_list_indent_spaces(convert: Callable[..., str]) -> None:
     result = _get_list_indent("spaces", 2)
     assert result == "  "
 
 
-def test_convert_as_inline_strips_trailing_newlines(convert: Callable[[str, ...], str]) -> None:
+def test_convert_as_inline_strips_trailing_newlines(convert: Callable[..., str]) -> None:
     html = "<p>Test content\n</p>"
     result = convert(html, convert_as_inline=True)
     assert not result.endswith("\n")
     assert result == "Test content"
 
 
-def test_empty_html_error(convert: Callable[[str, ...], str]) -> None:
+def test_empty_html_error(convert: Callable[..., str]) -> None:
     with pytest.raises(EmptyHtmlError):
         convert("")
 
     convert("   \n\n  ")
 
 
-def test_conflicting_options_error(convert: Callable[[str, ...], str]) -> None:
+def test_conflicting_options_error(convert: Callable[..., str]) -> None:
     with pytest.raises(ConflictingOptionsError):
         convert("<p>test</p>", strip=["p"], convert=["p"])
 
@@ -51,13 +51,13 @@ def test_missing_dependency_error(monkeypatch: Any) -> None:
         convert_to_markdown("<p>test</p>", parser="lxml")
 
 
-def test_beautifulsoup_input(convert: Callable[[str, ...], str]) -> None:
+def test_beautifulsoup_input(convert: Callable[..., str]) -> None:
     soup = BeautifulSoup("<p>test</p>", "html.parser")
     result = convert(soup)
     assert "test" in result
 
 
-def test_metadata_extraction(convert: Callable[[str, ...], str]) -> None:
+def test_metadata_extraction(convert: Callable[..., str]) -> None:
     html = """
     <html>
     <head>
@@ -85,7 +85,7 @@ def test_metadata_extraction(convert: Callable[[str, ...], str]) -> None:
     assert "Content" in result_no_meta
 
 
-def test_stream_processing(convert: Callable[[str, ...], str]) -> None:
+def test_stream_processing(convert: Callable[..., str]) -> None:
     html = "<p>" + "test " * 1000 + "</p>"
 
     chunks = list(convert_to_markdown_stream(html, chunk_size=100))
@@ -96,7 +96,7 @@ def test_stream_processing(convert: Callable[[str, ...], str]) -> None:
     assert len(chunks) > 1
 
 
-def test_progress_callback(convert: Callable[[str, ...], str]) -> None:
+def test_progress_callback(convert: Callable[..., str]) -> None:
     html = "<p>" + "test " * 1000 + "</p>"
     progress_calls = []
 
@@ -107,13 +107,13 @@ def test_progress_callback(convert: Callable[[str, ...], str]) -> None:
     assert len(progress_calls) > 0
 
 
-def test_strip_newlines(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines(convert: Callable[..., str]) -> None:
     html = "<p>Line 1\nLine 2\rLine 3</p>"
     result = convert(html, strip_newlines=True)
     assert "Line 1 Line 2 Line 3" in result
 
 
-def test_convert_as_inline(convert: Callable[[str, ...], str]) -> None:
+def test_convert_as_inline(convert: Callable[..., str]) -> None:
     html = "<p>Paragraph text</p>"
     result = convert(html, convert_as_inline=True)
     assert not result.endswith("\n")
@@ -129,7 +129,7 @@ def test_parser_selection() -> None:
     assert "test" in result
 
 
-def test_whitespace_handling(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_handling(convert: Callable[..., str]) -> None:
     html = "  <p>text</p>"
     result = convert(html)
 
@@ -139,13 +139,13 @@ def test_whitespace_handling(convert: Callable[[str, ...], str]) -> None:
     assert "Para 2" in result
 
 
-def test_wbr_element_handling(convert: Callable[[str, ...], str]) -> None:
+def test_wbr_element_handling(convert: Callable[..., str]) -> None:
     html = "<p>long<wbr>word</p>"
     result = convert(html)
     assert "longword" in result
 
 
-def test_normalize_spaces_outside_code(convert: Callable[[str, ...], str]) -> None:
+def test_normalize_spaces_outside_code(convert: Callable[..., str]) -> None:
     html = """
     <p>Text   with    multiple     spaces</p>
     <pre><code>Code   with    preserved     spaces</code></pre>
@@ -170,7 +170,7 @@ def test_leading_whitespace_with_lxml() -> None:
         pytest.skip("lxml not available")
 
 
-def test_definition_list_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_definition_list_formatting(convert: Callable[..., str]) -> None:
     html = """
     <dl>
         <dt>Term</dt>
@@ -181,7 +181,7 @@ def test_definition_list_formatting(convert: Callable[[str, ...], str]) -> None:
     assert ":   " in result
 
 
-def test_as_optional_set_function(convert: Callable[[str, ...], str]) -> None:
+def test_as_optional_set_function(convert: Callable[..., str]) -> None:
     assert _as_optional_set(None) is None
 
     result = _as_optional_set("a,b,c")
@@ -199,7 +199,7 @@ def test_as_optional_set_function(convert: Callable[[str, ...], str]) -> None:
     assert result == expected
 
 
-def test_underlined_heading_conversion(convert: Callable[[str, ...], str]) -> None:
+def test_underlined_heading_conversion(convert: Callable[..., str]) -> None:
     html = "<h2>Header</h2><p>Next paragraph</p>"
     result = convert(html, heading_style="underlined")
 

--- a/tests/strip_newlines_test.py
+++ b/tests/strip_newlines_test.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def test_strip_newlines_basic(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_basic(convert: Callable[..., str]) -> None:
     html = """<p>Return a list of the words in the string, using <em>sep</em> as the delimiter
 string.  If <em>maxsplit</em> is given, at most <em>maxsplit</em> splits are done (thus,
 the list will have at most <code class="docutils literal notranslate"><span class="pre">maxsplit+1</span></code> elements).  If <em>maxsplit</em> is not
@@ -23,13 +23,13 @@ specified or <code class="docutils literal notranslate"><span class="pre">-1</sp
     assert "Return a list of the words in the string" in result_stripped
 
 
-def test_strip_newlines_with_carriage_returns(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_with_carriage_returns(convert: Callable[..., str]) -> None:
     html_with_cr = "Text with\r\nnewlines and\rcarriage returns"
     result = convert(html_with_cr, strip_newlines=True)
     assert "Text with newlines and carriage returns" in result
 
 
-def test_strip_newlines_with_multiple_paragraphs(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_with_multiple_paragraphs(convert: Callable[..., str]) -> None:
     html = """<p>First paragraph
 with a line break.</p>
 <p>Second paragraph
@@ -43,7 +43,7 @@ also with a line break.</p>"""
     assert "\n\n" in result
 
 
-def test_strip_newlines_preserves_pre_blocks(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_preserves_pre_blocks(convert: Callable[..., str]) -> None:
     html = """<p>Regular text
 with newline.</p>
 <pre>Code block
@@ -56,7 +56,7 @@ newlines</pre>"""
     assert "Code block with preserved newlines" in result
 
 
-def test_strip_newlines_with_inline_elements(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_with_inline_elements(convert: Callable[..., str]) -> None:
     html = """<p>This is <strong>bold
 text</strong> and <em>italic
 text</em> with line breaks.</p>"""
@@ -65,21 +65,21 @@ text</em> with line breaks.</p>"""
     assert result == "This is **bold text** and *italic text* with line breaks.\n\n"
 
 
-def test_strip_newlines_empty_html(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_empty_html(convert: Callable[..., str]) -> None:
     html = "\n\n"
 
     result = convert(html, strip_newlines=True)
     assert result.strip() == ""
 
 
-def test_strip_newlines_preserves_br_tags(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_preserves_br_tags(convert: Callable[..., str]) -> None:
     html = "<p>Line one<br>Line two</p>"
 
     result = convert(html, strip_newlines=True)
     assert result == "Line one  \nLine two\n\n"
 
 
-def test_strip_newlines_with_lists(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_with_lists(convert: Callable[..., str]) -> None:
     html = """<ul>
 <li>Item one
 with newline</li>
@@ -92,7 +92,7 @@ also with newline</li>
     assert "* Item two also with newline\n" in result
 
 
-def test_strip_newlines_complex_html(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_complex_html(convert: Callable[..., str]) -> None:
     html = """<div>
     <h1>Title with
     newline</h1>
@@ -109,7 +109,7 @@ def test_strip_newlines_complex_html(convert: Callable[[str, ...], str]) -> None
     assert "> Quote with newline." in result
 
 
-def test_strip_newlines_with_only_carriage_returns(convert: Callable[[str, ...], str]) -> None:
+def test_strip_newlines_with_only_carriage_returns(convert: Callable[..., str]) -> None:
     html = "Text\rwith\rcarriage\rreturns"
     result = convert(html, strip_newlines=True)
     assert "Text with carriage returns" in result

--- a/tests/tables_test.py
+++ b/tests/tables_test.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 import pytest
 
 
-def test_table_first_row_in_tbody_without_previous_sibling(convert: Callable[[str, ...], str]) -> None:
+def test_table_first_row_in_tbody_without_previous_sibling(convert: Callable[..., str]) -> None:
     html = """<table>
     <tbody>
         <tr><td>Cell 1</td><td>Cell 2</td></tr>
@@ -25,7 +25,7 @@ def test_table_first_row_in_tbody_without_previous_sibling(convert: Callable[[st
     assert result == expected
 
 
-def test_basic_table(convert: Callable[[str, ...], str]) -> None:
+def test_basic_table(convert: Callable[..., str]) -> None:
     html = """<table>
     <tr><th>Header 1</th><th>Header 2</th></tr>
     <tr><td>Cell 1</td><td>Cell 2</td></tr>
@@ -36,7 +36,7 @@ def test_basic_table(convert: Callable[[str, ...], str]) -> None:
     assert "| Cell 1 | Cell 2 |" in result
 
 
-def test_simple_table_structure(convert: Callable[[str, ...], str]) -> None:
+def test_simple_table_structure(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <th>Header 1</th>
@@ -53,7 +53,7 @@ def test_simple_table_structure(convert: Callable[[str, ...], str]) -> None:
     assert "| Data 1 | Data 2 |" in result
 
 
-def test_table_with_sections(convert: Callable[[str, ...], str]) -> None:
+def test_table_with_sections(convert: Callable[..., str]) -> None:
     html = """<table>
         <thead>
             <tr><th>Name</th><th>Age</th></tr>
@@ -73,46 +73,46 @@ def test_table_with_sections(convert: Callable[[str, ...], str]) -> None:
     assert "| Total | 2 |" in result
 
 
-def test_tbody_only(convert: Callable[[str, ...], str]) -> None:
+def test_tbody_only(convert: Callable[..., str]) -> None:
     html = "<table><tbody><tr><td>Data</td></tr></tbody></table>"
     result = convert(html)
     assert "| Data |" in result
 
 
-def test_tfoot_basic(convert: Callable[[str, ...], str]) -> None:
+def test_tfoot_basic(convert: Callable[..., str]) -> None:
     html = "<table><tfoot><tr><td>Footer</td></tr></tfoot><tbody><tr><td>Data</td></tr></tbody></table>"
     result = convert(html)
     assert "| Footer |" in result
     assert "| Data |" in result
 
 
-def test_table_caption(convert: Callable[[str, ...], str]) -> None:
+def test_table_caption(convert: Callable[..., str]) -> None:
     html = "<table><caption>Table Caption</caption><tr><td>Data</td></tr></table>"
     result = convert(html)
     assert "*Table Caption*" in result
     assert "| Data |" in result
 
 
-def test_caption_with_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_caption_with_formatting(convert: Callable[..., str]) -> None:
     html = "<table><caption>Sales <strong>Report</strong> 2023</caption><tr><td>Data</td></tr></table>"
     result = convert(html)
     assert "*Sales **Report** 2023*" in result
 
 
-def test_caption_empty(convert: Callable[[str, ...], str]) -> None:
+def test_caption_empty(convert: Callable[..., str]) -> None:
     html = "<table><caption></caption><tr><td>Data</td></tr></table>"
     result = convert(html)
     assert "*" not in result
     assert "| Data |" in result
 
 
-def test_caption_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_caption_inline_mode(convert: Callable[..., str]) -> None:
     html = "<caption>Inline Caption</caption>"
     result = convert(html, convert_as_inline=True)
     assert result == "Inline Caption"
 
 
-def test_colgroup_removed(convert: Callable[[str, ...], str]) -> None:
+def test_colgroup_removed(convert: Callable[..., str]) -> None:
     html = """<table>
     <colgroup>
         <col style="width: 50%">
@@ -141,7 +141,7 @@ def test_colgroup_removed(convert: Callable[[str, ...], str]) -> None:
     assert "| Cell 1 | Cell 2 |" in result
 
 
-def test_col_elements_removed(convert: Callable[[str, ...], str]) -> None:
+def test_col_elements_removed(convert: Callable[..., str]) -> None:
     html = """<table>
     <col width="100">
     <tr><td>Cell</td></tr>
@@ -154,14 +154,14 @@ def test_col_elements_removed(convert: Callable[[str, ...], str]) -> None:
     assert "| Cell |" in result
 
 
-def test_colgroup_with_span(convert: Callable[[str, ...], str]) -> None:
+def test_colgroup_with_span(convert: Callable[..., str]) -> None:
     html = '<table><colgroup span="3"><col><col></colgroup><tr><td>A</td><td>B</td></tr></table>'
     result = convert(html)
     assert '<colgroup span="3">' not in result
     assert "| A | B |" in result
 
 
-def test_col_with_attributes(convert: Callable[[str, ...], str]) -> None:
+def test_col_with_attributes(convert: Callable[..., str]) -> None:
     html = '<table><colgroup><col width="50%" style="background: yellow;" span="2"></colgroup><tr><td>A</td><td>B</td></tr></table>'
     result = convert(html)
     assert 'width="50%"' not in result
@@ -170,7 +170,7 @@ def test_col_with_attributes(convert: Callable[[str, ...], str]) -> None:
     assert "| A | B |" in result
 
 
-def test_table_with_colspan(convert: Callable[[str, ...], str]) -> None:
+def test_table_with_colspan(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <th colspan="2">Merged Header</th>
@@ -185,7 +185,7 @@ def test_table_with_colspan(convert: Callable[[str, ...], str]) -> None:
     assert "| Data 1 | Data 2 |" in result
 
 
-def test_links_in_rowspan_cells(convert: Callable[[str, ...], str]) -> None:
+def test_links_in_rowspan_cells(convert: Callable[..., str]) -> None:
     html = """<table>
     <tr>
         <td rowspan="2">Cell A</td>
@@ -202,7 +202,7 @@ def test_links_in_rowspan_cells(convert: Callable[[str, ...], str]) -> None:
     assert "[Link C](https://example.com)" in result
 
 
-def test_complex_table_with_rowspan_and_links(convert: Callable[[str, ...], str]) -> None:
+def test_complex_table_with_rowspan_and_links(convert: Callable[..., str]) -> None:
     html = """<table>
     <tr>
         <th>Header 1</th>
@@ -232,7 +232,7 @@ def test_complex_table_with_rowspan_and_links(convert: Callable[[str, ...], str]
     assert "[Fourth Link](https://test.com)" in result
 
 
-def test_multiple_rowspan_levels(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_rowspan_levels(convert: Callable[..., str]) -> None:
     html = """<table>
     <tr>
         <td rowspan="3">A</td>
@@ -253,7 +253,7 @@ def test_multiple_rowspan_levels(convert: Callable[[str, ...], str]) -> None:
     assert "[D](https://example.com)" in result
 
 
-def test_complex_rowspan_case(convert: Callable[[str, ...], str]) -> None:
+def test_complex_rowspan_case(convert: Callable[..., str]) -> None:
     html = """<table>
     <tbody>
     <tr>
@@ -275,7 +275,7 @@ def test_complex_rowspan_case(convert: Callable[[str, ...], str]) -> None:
     assert "EDCEDD" not in result or ("[EDC]" in result and "[EDD]" in result)
 
 
-def test_image_in_table_cell(convert: Callable[[str, ...], str]) -> None:
+def test_image_in_table_cell(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="test.jpg" alt="Test Image">Cell with image</td>
@@ -289,7 +289,7 @@ def test_image_in_table_cell(convert: Callable[[str, ...], str]) -> None:
     assert "Regular cell" in result
 
 
-def test_image_with_title_in_table(convert: Callable[[str, ...], str]) -> None:
+def test_image_with_title_in_table(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="icon.png" alt="Icon" title="An icon">Text</td>
@@ -301,7 +301,7 @@ def test_image_with_title_in_table(convert: Callable[[str, ...], str]) -> None:
     assert "Text" in result
 
 
-def test_image_without_alt_in_table(convert: Callable[[str, ...], str]) -> None:
+def test_image_without_alt_in_table(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="image.gif">Content</td>
@@ -313,7 +313,7 @@ def test_image_without_alt_in_table(convert: Callable[[str, ...], str]) -> None:
     assert "Content" in result
 
 
-def test_multiple_images_in_table_cell(convert: Callable[[str, ...], str]) -> None:
+def test_multiple_images_in_table_cell(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="img1.jpg" alt="First"> and <img src="img2.jpg" alt="Second"></td>
@@ -326,7 +326,7 @@ def test_multiple_images_in_table_cell(convert: Callable[[str, ...], str]) -> No
     assert "and" in result
 
 
-def test_image_in_table_header(convert: Callable[[str, ...], str]) -> None:
+def test_image_in_table_header(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <th><img src="header.png" alt="Header Icon">Column</th>
@@ -342,7 +342,7 @@ def test_image_in_table_header(convert: Callable[[str, ...], str]) -> None:
     assert "Data" in result
 
 
-def test_image_with_dimensions_in_table(convert: Callable[[str, ...], str]) -> None:
+def test_image_with_dimensions_in_table(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="sized.jpg" alt="Sized" width="100" height="50">Text</td>
@@ -354,7 +354,7 @@ def test_image_with_dimensions_in_table(convert: Callable[[str, ...], str]) -> N
     assert "Text" in result
 
 
-def test_keep_inline_images_in_tables(convert: Callable[[str, ...], str]) -> None:
+def test_keep_inline_images_in_tables(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="table.jpg" alt="Table Image">In table</td>
@@ -372,7 +372,7 @@ def test_keep_inline_images_in_tables(convert: Callable[[str, ...], str]) -> Non
     assert "![Heading Image](heading.jpg)" in result_with_h1
 
 
-def test_complex_table_with_images(convert: Callable[[str, ...], str]) -> None:
+def test_complex_table_with_images(convert: Callable[..., str]) -> None:
     html = """<table>
         <thead>
             <tr>
@@ -401,7 +401,7 @@ def test_complex_table_with_images(convert: Callable[[str, ...], str]) -> None:
     assert "Go forward" in result
 
 
-def test_table_with_mixed_content(convert: Callable[[str, ...], str]) -> None:
+def test_table_with_mixed_content(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr>
             <td><img src="test.jpg" alt="Test"> <strong>Bold text</strong> and <em>italic</em></td>
@@ -417,7 +417,7 @@ def test_table_with_mixed_content(convert: Callable[[str, ...], str]) -> None:
     assert "![Icon](icon.png)" in result
 
 
-def test_complete_table_structure(convert: Callable[[str, ...], str]) -> None:
+def test_complete_table_structure(convert: Callable[..., str]) -> None:
     html = """<table>
         <caption>Employee Database</caption>
         <colgroup>
@@ -466,7 +466,7 @@ def test_complete_table_structure(convert: Callable[[str, ...], str]) -> None:
     assert "| Total Employees | 2 | $140,000 |" in result
 
 
-def test_nested_colgroups(convert: Callable[[str, ...], str]) -> None:
+def test_nested_colgroups(convert: Callable[..., str]) -> None:
     html = """<table>
         <colgroup span="2">
             <col style="background: red;">
@@ -489,7 +489,7 @@ def test_nested_colgroups(convert: Callable[[str, ...], str]) -> None:
     assert "| Red | Blue | Green |" in result
 
 
-def test_table_with_caption_and_formatting(convert: Callable[[str, ...], str]) -> None:
+def test_table_with_caption_and_formatting(convert: Callable[..., str]) -> None:
     html = """<table>
         <caption><strong>Q4 2023</strong> Sales Report - <em>Final</em></caption>
         <tr>
@@ -502,7 +502,7 @@ def test_table_with_caption_and_formatting(convert: Callable[[str, ...], str]) -
     assert "| Product A | $1,000 |" in result
 
 
-def test_empty_table_elements(convert: Callable[[str, ...], str]) -> None:
+def test_empty_table_elements(convert: Callable[..., str]) -> None:
     html = """<table>
         <caption></caption>
         <colgroup></colgroup>
@@ -521,7 +521,7 @@ def test_empty_table_elements(convert: Callable[[str, ...], str]) -> None:
     assert "| Only Data |" in result
 
 
-def test_mixed_table_elements(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_table_elements(convert: Callable[..., str]) -> None:
     html = """<table>
         <caption>Mixed Table</caption>
         <tr>
@@ -539,19 +539,19 @@ def test_mixed_table_elements(convert: Callable[[str, ...], str]) -> None:
     assert "| Body Data |" in result
 
 
-def test_table_sections_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_table_sections_inline_mode(convert: Callable[..., str]) -> None:
     html = "<thead><tr><th>Header</th></tr></thead>"
     result = convert(html, convert_as_inline=True)
     assert "Header" in result
 
 
-def test_colgroup_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_colgroup_inline_mode(convert: Callable[..., str]) -> None:
     html = "<colgroup><col><col></colgroup>"
     result = convert(html, convert_as_inline=True)
     assert result == ""
 
 
-def test_col_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_col_inline_mode(convert: Callable[..., str]) -> None:
     html = '<col width="50%">'
     result = convert(html, convert_as_inline=True)
     assert result == ""
@@ -569,7 +569,7 @@ def test_col_inline_mode(convert: Callable[[str, ...], str]) -> None:
         ('<table><tr><td><img src="test.jpg" alt="Test">Text</td></tr></table>', ["![Test](test.jpg)", "Text"]),
     ],
 )
-def test_table_conversion_patterns(html: str, should_contain: list[str], convert: Callable[[str, ...], str]) -> None:
+def test_table_conversion_patterns(html: str, should_contain: list[str], convert: Callable[..., str]) -> None:
     result = convert(html)
     for expected in should_contain:
         assert expected in result
@@ -583,13 +583,13 @@ def test_table_conversion_patterns(html: str, should_contain: list[str], convert
         ("<table><caption></caption><tr><td>Data</td></tr></table>", ["*"]),
     ],
 )
-def test_table_element_removal(html: str, should_not_contain: list[str], convert: Callable[[str, ...], str]) -> None:
+def test_table_element_removal(html: str, should_not_contain: list[str], convert: Callable[..., str]) -> None:
     result = convert(html)
     for unwanted in should_not_contain:
         assert unwanted not in result
 
 
-def test_table_with_tbody_but_no_thead(convert: Callable[[str, ...], str]) -> None:
+def test_table_with_tbody_but_no_thead(convert: Callable[..., str]) -> None:
     html = """
     <table>
         <tbody>
@@ -603,7 +603,7 @@ def test_table_with_tbody_but_no_thead(convert: Callable[[str, ...], str]) -> No
     assert "| Cell 3 | Cell 4 |" in result
 
 
-def test_table_first_row_directly_in_table(convert: Callable[[str, ...], str]) -> None:
+def test_table_first_row_directly_in_table(convert: Callable[..., str]) -> None:
     html = """<table>
         <tr><td>Cell1</td><td>Cell2</td></tr>
         <tr><td>Cell3</td><td>Cell4</td></tr>
@@ -614,13 +614,13 @@ def test_table_first_row_directly_in_table(convert: Callable[[str, ...], str]) -
     assert "| Cell3 | Cell4 |" in result
 
 
-def test_tbody_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_tbody_inline_mode(convert: Callable[..., str]) -> None:
     html = "<tbody><tr><td>Cell</td></tr></tbody>"
     result = convert(html, convert_as_inline=True)
     assert "Cell" in result
 
 
-def test_tfoot_inline_mode(convert: Callable[[str, ...], str]) -> None:
+def test_tfoot_inline_mode(convert: Callable[..., str]) -> None:
     html = "<tfoot><tr><td>Footer</td></tr></tfoot>"
     result = convert(html, convert_as_inline=True)
     assert "Footer" in result
@@ -714,6 +714,6 @@ def test_tfoot_inline_mode(convert: Callable[[str, ...], str]) -> None:
         ),
     ],
 )
-def test_table_cell_multiline_content_issues(html: str, expected: str, convert: Callable[[str, ...], str]) -> None:
+def test_table_cell_multiline_content_issues(html: str, expected: str, convert: Callable[..., str]) -> None:
     result = convert(html, br_in_tables=True)
     assert result == expected

--- a/tests/whitespace_test.py
+++ b/tests/whitespace_test.py
@@ -14,26 +14,26 @@ if TYPE_CHECKING:
 import pytest
 
 
-def test_normalized_mode_basic(convert: Callable[[str, ...], str]) -> None:
+def test_normalized_mode_basic(convert: Callable[..., str]) -> None:
     assert convert("<b>bold</b> text", whitespace_mode="normalized") == "**bold** text"
     assert convert("<b>bold</b>\ntext", whitespace_mode="normalized") == "**bold** text"
     assert convert("text    with    spaces", whitespace_mode="normalized") == "text with spaces"
 
 
-def test_normalized_mode(convert: Callable[[str, ...], str]) -> None:
+def test_normalized_mode(convert: Callable[..., str]) -> None:
     html = "<b>bold</b>\n text"
     result = convert(html, whitespace_mode="normalized")
     assert "**bold**" in result
 
 
-def test_strict_mode_preservation(convert: Callable[[str, ...], str]) -> None:
+def test_strict_mode_preservation(convert: Callable[..., str]) -> None:
     html = "<b>bold</b>  \n  text"
     result = convert(html, whitespace_mode="strict")
     assert "**bold**" in result
     assert "text" in result
 
 
-def test_unicode_space_normalization(convert: Callable[[str, ...], str]) -> None:
+def test_unicode_space_normalization(convert: Callable[..., str]) -> None:
     test_cases = [
         ("\u00a0", " "),
         ("\u1680", " "),
@@ -59,20 +59,20 @@ def test_unicode_space_normalization(convert: Callable[[str, ...], str]) -> None
         assert result == "text with space", f"Failed for Unicode {ord(unicode_space):04X}"
 
 
-def test_block_element_spacing(convert: Callable[[str, ...], str]) -> None:
+def test_block_element_spacing(convert: Callable[..., str]) -> None:
     assert convert("<div>div1</div><div>div2</div>", whitespace_mode="normalized") == "div1\n\ndiv2\n\n"
     assert convert("<p>para1</p><p>para2</p>", whitespace_mode="normalized") == "para1\n\npara2\n\n"
     assert convert("<div>div</div><p>para</p>", whitespace_mode="normalized") == "div\n\npara\n\n"
 
 
-def test_inline_element_spacing(convert: Callable[[str, ...], str]) -> None:
+def test_inline_element_spacing(convert: Callable[..., str]) -> None:
     assert convert("<em>italic</em> text") == "*italic* text"
     assert convert("text <strong>bold</strong>") == "text **bold**"
     assert convert('<a href="#">link</a> text') == "[link](#) text"
     assert convert('text <a href="#">link</a>') == "text [link](#)"
 
 
-def test_adjacent_inline_elements(convert: Callable[[str, ...], str]) -> None:
+def test_adjacent_inline_elements(convert: Callable[..., str]) -> None:
     html = "<b>bold</b><i>italic</i>"
     result = convert(html, whitespace_mode="normalized")
     assert result == "**bold***italic*"
@@ -82,7 +82,7 @@ def test_adjacent_inline_elements(convert: Callable[[str, ...], str]) -> None:
     assert result == "**bold** *italic*"
 
 
-def test_whitespace_in_lists(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_in_lists(convert: Callable[..., str]) -> None:
     html = """
     <ul>
         <li>item 1</li>
@@ -94,7 +94,7 @@ def test_whitespace_in_lists(convert: Callable[[str, ...], str]) -> None:
     assert "* item 2" in result
 
 
-def test_whitespace_in_nested_structures(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_in_nested_structures(convert: Callable[..., str]) -> None:
     html = """
     <div>
         <p>Paragraph in div</p>
@@ -108,7 +108,7 @@ def test_whitespace_in_nested_structures(convert: Callable[[str, ...], str]) -> 
     assert "* List item" in result
 
 
-def test_pre_and_code_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_pre_and_code_whitespace(convert: Callable[..., str]) -> None:
     pre_html = "<pre>  line 1\n    line 2  </pre>"
     pre_result = convert(pre_html, whitespace_mode="normalized")
     assert "  line 1\n    line 2  " in pre_result
@@ -119,19 +119,19 @@ def test_pre_and_code_whitespace(convert: Callable[[str, ...], str]) -> None:
     assert "spaced" in code_result
 
 
-def test_tab_character_handling(convert: Callable[[str, ...], str]) -> None:
+def test_tab_character_handling(convert: Callable[..., str]) -> None:
     html = "text\twith\ttabs"
     result = convert(html, whitespace_mode="normalized")
     assert result == "text with tabs"
 
 
-def test_mixed_whitespace(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_whitespace(convert: Callable[..., str]) -> None:
     html = "  \t \n  text  \n\t  "
     result = convert(html, whitespace_mode="normalized")
     assert result.strip() == "text"
 
 
-def test_br_tag_handling(convert: Callable[[str, ...], str]) -> None:
+def test_br_tag_handling(convert: Callable[..., str]) -> None:
     html = "line1<br>line2<br/>line3"
 
     result = convert(html, newline_style="spaces")
@@ -141,18 +141,18 @@ def test_br_tag_handling(convert: Callable[[str, ...], str]) -> None:
     assert result == "line1\\\nline2\\\nline3"
 
 
-def test_empty_elements(convert: Callable[[str, ...], str]) -> None:
+def test_empty_elements(convert: Callable[..., str]) -> None:
     assert convert("<div></div>") == ""
     assert convert("<p></p>") == ""
     assert convert("<span></span>") == ""
 
 
-def test_whitespace_only_elements(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_only_elements(convert: Callable[..., str]) -> None:
     assert convert("<div>   </div>", whitespace_mode="normalized").strip() == ""
     assert "\n\t" in convert("<pre>\n\t</pre>", whitespace_mode="normalized")
 
 
-def test_complex_real_world_example(convert: Callable[[str, ...], str]) -> None:
+def test_complex_real_world_example(convert: Callable[..., str]) -> None:
     html = """
     <article>
         <h1>Title</h1>
@@ -177,7 +177,7 @@ def test_complex_real_world_example(convert: Callable[[str, ...], str]) -> None:
     assert "Final paragraph." in result
 
 
-def test_block_element_newline_separation(convert: Callable[[str, ...], str]) -> None:
+def test_block_element_newline_separation(convert: Callable[..., str]) -> None:
     html = """<b>test1</b>
  test2
 
@@ -222,7 +222,7 @@ test4
         ("<div>block</div>text", "block\n\ntext"),
     ],
 )
-def test_whitespace_patterns(html: str, expected: str, convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_patterns(html: str, expected: str, convert: Callable[..., str]) -> None:
     result = convert(html, whitespace_mode="normalized")
     assert expected in result
 
@@ -255,7 +255,7 @@ def test_whitespace_patterns(html: str, expected: str, convert: Callable[[str, .
     ],
 )
 def test_block_element_separation_comprehensive(
-    html: str, expected_lines: list[str], description: str, convert: Callable[[str, ...], str]
+    html: str, expected_lines: list[str], description: str, convert: Callable[..., str]
 ) -> None:
     result = convert(html, whitespace_mode="normalized")
 
@@ -271,7 +271,7 @@ def test_block_element_separation_comprehensive(
         )
 
 
-def test_carriage_return_normalization(convert: Callable[[str, ...], str]) -> None:
+def test_carriage_return_normalization(convert: Callable[..., str]) -> None:
     html = "<p>Line 1\rLine 2\r\nLine 3</p>"
     result = convert(html)
     assert "Line 1\nLine 2\nLine 3" in result
@@ -281,7 +281,7 @@ def test_carriage_return_normalization(convert: Callable[[str, ...], str]) -> No
     assert "Text\nCarriage" in result or "Text Carriage" in result
 
 
-def test_empty_text_processing(convert: Callable[[str, ...], str]) -> None:
+def test_empty_text_processing(convert: Callable[..., str]) -> None:
     html = "<p></p>"
     result = convert(html)
     assert result.strip() == ""
@@ -295,19 +295,19 @@ def test_empty_text_processing(convert: Callable[[str, ...], str]) -> None:
     assert result.strip() == ""
 
 
-def test_strict_mode_text_preservation(convert: Callable[[str, ...], str]) -> None:
+def test_strict_mode_text_preservation(convert: Callable[..., str]) -> None:
     html = "<pre>  Text  with   spaces  </pre>"
     result = convert(html, whitespace_mode="strict")
     assert "  Text  with   spaces  " in result
 
 
-def test_strict_whitespace_mode(convert: Callable[[str, ...], str]) -> None:
+def test_strict_whitespace_mode(convert: Callable[..., str]) -> None:
     html = "<p>First paragraph</p><p>Second paragraph</p>"
     result = convert(html, whitespace_mode="strict")
     assert result
 
 
-def test_block_spacing_combinations(convert: Callable[[str, ...], str]) -> None:
+def test_block_spacing_combinations(convert: Callable[..., str]) -> None:
     html = "<div>Div content</div><blockquote>Quote content</blockquote>"
     result = convert(html)
     assert "Div content" in result
@@ -324,14 +324,14 @@ def test_block_spacing_combinations(convert: Callable[[str, ...], str]) -> None:
     assert "Content" in result
 
 
-def test_mixed_block_and_inline_elements(convert: Callable[[str, ...], str]) -> None:
+def test_mixed_block_and_inline_elements(convert: Callable[..., str]) -> None:
     html = "<p>Text with <strong>inline</strong> element</p><div>Block element</div>"
     result = convert(html)
     assert "Text with **inline** element" in result
     assert "Block element" in result
 
 
-def test_whitespace_trailing_with_inline_sibling(convert: Callable[[str, ...], str]) -> None:
+def test_whitespace_trailing_with_inline_sibling(convert: Callable[..., str]) -> None:
     html = "Text\n<span>inline</span>"
     result = convert(html, whitespace_mode="normalized")
     assert "Text inline" in result
@@ -341,7 +341,7 @@ def test_whitespace_trailing_with_inline_sibling(convert: Callable[[str, ...], s
     assert "Text *emphasized*" in result
 
 
-def test_unicode_whitespace_strict_mode(convert: Callable[[str, ...], str]) -> None:
+def test_unicode_whitespace_strict_mode(convert: Callable[..., str]) -> None:
     html = "<p>Text\u00a0with\u2003unicode\u00a0spaces</p>"
 
     result_strict = convert(html, whitespace_mode="strict")
@@ -354,14 +354,14 @@ def test_unicode_whitespace_strict_mode(convert: Callable[[str, ...], str]) -> N
     assert "Text with unicode spaces" in result_normalized
 
 
-def test_strict_mode_block_spacing(convert: Callable[[str, ...], str]) -> None:
+def test_strict_mode_block_spacing(convert: Callable[..., str]) -> None:
     html = "<p>First paragraph</p><p>Second paragraph</p>"
     result = convert(html, whitespace_mode="strict")
     assert "First paragraph" in result
     assert "Second paragraph" in result
 
 
-def test_block_spacing_with_double_newline_elements(convert: Callable[[str, ...], str]) -> None:
+def test_block_spacing_with_double_newline_elements(convert: Callable[..., str]) -> None:
     html = "<div>Content</div><p>Paragraph</p>"
     result = convert(html, whitespace_mode="normalized")
     assert "Content\n\nParagraph" in result
@@ -376,7 +376,7 @@ def test_block_spacing_with_double_newline_elements(convert: Callable[[str, ...]
     assert "After table" in result
 
 
-def test_block_spacing_with_single_newline_elements(convert: Callable[[str, ...], str]) -> None:
+def test_block_spacing_with_single_newline_elements(convert: Callable[..., str]) -> None:
     html = "<ul><li>Item 1</li><li>Item 2</li></ul>"
     result = convert(html, whitespace_mode="normalized")
     assert "* Item 1\n* Item 2" in result
@@ -392,7 +392,7 @@ def test_block_spacing_with_single_newline_elements(convert: Callable[[str, ...]
     assert "Cell 2" in result
 
 
-def test_block_spacing_heading_elements(convert: Callable[[str, ...], str]) -> None:
+def test_block_spacing_heading_elements(convert: Callable[..., str]) -> None:
     html = "<h1>Heading 1</h1><p>Content</p>"
     result = convert(html, whitespace_mode="normalized", heading_style="atx")
     assert "# Heading 1\n\nContent" in result
@@ -407,7 +407,7 @@ def test_block_spacing_heading_elements(convert: Callable[[str, ...], str]) -> N
         assert f"{'#' * i} Heading {i}\n\nContent" in result
 
 
-def test_block_spacing_non_block_next_sibling(convert: Callable[[str, ...], str]) -> None:
+def test_block_spacing_non_block_next_sibling(convert: Callable[..., str]) -> None:
     html = "<div>Content</div>plain text"
     result = convert(html, whitespace_mode="normalized")
     assert "Content\n\nplain text" in result
@@ -511,12 +511,10 @@ Div content
     ],
 )
 def test_whitespace_and_spacing_issues(
-    html: str, expected: str, whitespace_mode: str | None, convert: Callable[[str, ...], str], parser: str
+    html: str, expected: str, whitespace_mode: str | None, convert: Callable[..., str], parser: str
 ) -> None:
     result = convert(html, whitespace_mode=whitespace_mode) if whitespace_mode else convert(html)
 
-    # html5lib parser handles double newlines between inline elements differently in strict mode
-    # This is an acceptable parser-specific difference for this edge case
     if (
         parser == "html5lib"
         and whitespace_mode == "strict"

--- a/uv.lock
+++ b/uv.lock
@@ -208,8 +208,10 @@ lxml = [
 dev = [
     { name = "beautifulsoup4", extra = ["html5lib", "lxml"] },
     { name = "covdefaults" },
+    { name = "memray" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
@@ -234,8 +236,10 @@ dev = [
     { name = "beautifulsoup4", extras = ["html5lib"], specifier = ">=4.13.5" },
     { name = "beautifulsoup4", extras = ["lxml"], specifier = ">=4.13.5" },
     { name = "covdefaults", specifier = ">=2.3" },
+    { name = "memray", specifier = ">=1.18.0" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3" },
+    { name = "psutil", specifier = ">=7.1.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-benchmark", specifier = ">=5.1" },
     { name = "pytest-cov", specifier = ">=7" },
@@ -275,6 +279,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
 ]
 
 [[package]]
@@ -399,6 +427,154 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119, upload-time = "2025-09-22T04:04:51.801Z" },
     { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314, upload-time = "2025-09-22T04:04:55.024Z" },
     { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768, upload-time = "2025-09-22T04:04:57.097Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+plugins = [
+    { name = "mdit-py-plugins" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393, upload-time = "2024-10-18T15:20:52.426Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732, upload-time = "2024-10-18T15:20:53.578Z" },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866, upload-time = "2024-10-18T15:20:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964, upload-time = "2024-10-18T15:20:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977, upload-time = "2024-10-18T15:20:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366, upload-time = "2024-10-18T15:20:58.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091, upload-time = "2024-10-18T15:20:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065, upload-time = "2024-10-18T15:21:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514, upload-time = "2024-10-18T15:21:01.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload-time = "2024-10-18T15:21:06.495Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload-time = "2024-10-18T15:21:07.295Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload-time = "2024-10-18T15:21:08.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload-time = "2024-10-18T15:21:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload-time = "2024-10-18T15:21:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload-time = "2024-10-18T15:21:11.005Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload-time = "2024-10-18T15:21:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "memray"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "rich" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/cd/3d66fc07f347bf4586305f9fd94a412ee52f9da82bdf2eceffff2302f45a/memray-1.18.0.tar.gz", hash = "sha256:44160b46f0eca0d468f7d7ae8cc43245f8ff03bf9694db6a6e0bf54f88e7caa2", size = 1031186, upload-time = "2025-08-08T19:48:11.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/0b/5b05864dde626bd21343080f8d9d151de44eb51475b9adc3d33bba547239/memray-1.18.0-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:9c2f0b82567b71310df7733077fb33ef4d9858f0ac45299144f5b6335cd4ffc8", size = 786238, upload-time = "2025-08-08T19:47:03.933Z" },
+    { url = "https://files.pythonhosted.org/packages/55/72/bd26fe90cd23bc48083559cbfdb13708d4e34716caa35798cd81107d4325/memray-1.18.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91fd434833b5593e952a0abc53109842d2c7cd1d9074bc578f6199b81ebc6fc8", size = 761409, upload-time = "2025-08-08T19:47:05.923Z" },
+    { url = "https://files.pythonhosted.org/packages/01/96/1b70e58ddfcce8fe6454c1f53a1c93bb0d695dd99bbde400c323955e3eee/memray-1.18.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5c91ee7697a1ef0409ac033d5942abd4f7aa8711d1ae08abbf2622e5e9bae148", size = 7842266, upload-time = "2025-08-08T19:47:07.376Z" },
+    { url = "https://files.pythonhosted.org/packages/23/06/982bca8cb43f0f9c32aea189360caee3c84f08d5b42a5d88bf38f963e407/memray-1.18.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:af1785931c3f1507e12ab9e00352868e2a96988e57d94ec05d59bd0400740b14", size = 8082857, upload-time = "2025-08-08T19:47:08.73Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/bb/0b97842e058e4df994cc1483bfe9878f6df198a78400bea5388a844113bb/memray-1.18.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1aa4d302e66d285932aeed067b8854bf7645358aa35503147fdacae01e2ecf19", size = 7469580, upload-time = "2025-08-08T19:47:10.22Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a4/42eb2e734bd3f807f64baade86eab0093f9def69555f3e6257d9530770c3/memray-1.18.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29b82570f52f692160fcbe18d65c9d39594024a2fd2db316d8bd9bfdbd35cf12", size = 10297591, upload-time = "2025-08-08T19:47:11.808Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6a/95d4c48cf3192cec3e156d0bf5bfec7eb14dfde692e1df8b8f81eb376bdd/memray-1.18.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:791b7333174e68ac2a0ae1d09be7990909a791514f12e2105bb4849a9f44bbe8", size = 789349, upload-time = "2025-08-08T19:47:13.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bc/5e7dc055d8eb6c2f87889106564d4bc3e642552ec423eaa3e7ee14d4d589/memray-1.18.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:854dcb81c29f3deb18e5d8b2bd7caa4900009d13d31419ae4e8ca14a51d6d580", size = 765919, upload-time = "2025-08-08T19:47:15.056Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/93/4f0807283adecfd8d09243238375f49c3c03164e071a1571dcd306e9d1c5/memray-1.18.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ec5a40a314000fef2bc314dfa2e3058d6dd7fa8775605a9dbdfe9e547f233393", size = 7902242, upload-time = "2025-08-08T19:47:16.504Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e9/ffc6cca0bc45bf1eecf3f0072e989d8e6e8477d12bac244cccb5acd1c0a7/memray-1.18.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b775a7e695c99c51e09ca6e4487d1ae13f1697a31ad2b1cdf39d78702f854d26", size = 8158771, upload-time = "2025-08-08T19:47:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/27/18/1d4edeb7a063de70c16181f7d379e02d7cf86cce11ea94e59aeec5f07554/memray-1.18.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b89391ea26339e212075d90f4c22ed7ef586432c8787e9fc96b88e9c45f436", size = 7536293, upload-time = "2025-08-08T19:47:19.576Z" },
+    { url = "https://files.pythonhosted.org/packages/06/13/8739869250542d70ef68f8e2c4bb81eca6c1bd6beb8ce4c9d6ccc74f7b35/memray-1.18.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:93c2918241f12f0b269368777f526b7904c6a5d03c087244cf1ac7d7bbdbba11", size = 10368898, upload-time = "2025-08-08T19:47:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7a/c567c49d9d26ce909db81211b6e4930e0c3b72d6b4356139beede36417a1/memray-1.18.0-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:ee2219ce9f51bca4c80e85f1149f9003402b2e0f29b394012b9b89da6194fae9", size = 790019, upload-time = "2025-08-08T19:47:22.727Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/98/90e6f831d27920c35af0e1ca8987a642ab11930b4cbf4d1a6a6991a35a9a/memray-1.18.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d930d99c2217cff6690a9a7749f3aee98562dd8648c077444e02dd0bddc9c97", size = 767960, upload-time = "2025-08-08T19:47:23.72Z" },
+    { url = "https://files.pythonhosted.org/packages/db/81/f540baab15233f4c99463ff15bb24e816d74eea4d55f4a4e116e7062a4f4/memray-1.18.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:18102714e3d6159fbc196c45ce9bb9f82f91144a67f0aac36933ca8032c2624a", size = 7873583, upload-time = "2025-08-08T19:47:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/64/4d/05d1d9362c0ad14e47e8de79cb1177a2d172935ffa049858967aaacf6319/memray-1.18.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1c21db58e6708af69e04dc144ea166b615a5ed9062b061a3a23770c581ff79ad", size = 8146928, upload-time = "2025-08-08T19:47:26.107Z" },
+    { url = "https://files.pythonhosted.org/packages/79/32/a52f13cdc8ba4e2eb086231c4f2e788b15b456832dfe9705de59a0f767db/memray-1.18.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12d6761471eecff229240abebc5d5d7c22d19d77912c41e37805117c9bced026", size = 7508837, upload-time = "2025-08-08T19:47:27.655Z" },
+    { url = "https://files.pythonhosted.org/packages/15/95/25497cbe97e869237a8345188dceb7a085864881162c28dca6fbee0d41be/memray-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b76b8ff6212b6f51f16b06578f01cca7a841a8dc38818e95290d2ebf2bd518d1", size = 10339024, upload-time = "2025-08-08T19:47:29.34Z" },
+    { url = "https://files.pythonhosted.org/packages/17/57/a562eb5b5dad42aca4db82814af80ab4616cf25a131b88674a265de7343e/memray-1.18.0-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:dba5e8450d7dfc3189b7802213086ac183036a520eb417957389223317c9df1e", size = 786729, upload-time = "2025-08-08T19:47:30.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/26/6cf01b2479e156f9e924cfa0f70f73c04f58d730289e7322d4177d7266d0/memray-1.18.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:76e853178ab92c794e1aa556949536ec744a25af376b8150d39e925a42e9f3e0", size = 764627, upload-time = "2025-08-08T19:47:31.926Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8c/1a9b47017836428216cbb66ebc7b9a597e971d7b767d396bd155d78df7e1/memray-1.18.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5c5120a7a1f11fcd199b65106b9758e6fcef625e405bb7700f38bb0ad522618a", size = 7859660, upload-time = "2025-08-08T19:47:33.343Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/12/e8cd78a6a9c3c0f9c0c7df2337874e79eedda91c86f750a21e60a15a82f9/memray-1.18.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02e686ce643ff7c5216a59fc505787a9c16ca490446c151bb0c97754f85b9103", size = 8136143, upload-time = "2025-08-08T19:47:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/76/dfa1e3bcd4299a09db65bba468e615da6495aca68882b70f5bdb1b784c79/memray-1.18.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88568f547339ae0e41c116675690c7ceb3d73d474074ff8536e2b98d9b52427f", size = 7498501, upload-time = "2025-08-08T19:47:36.014Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e9/f78907fb25f16e783b51218b0e48ca63c1a0c7a7fa326300a70335c07d5a/memray-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8677b7ee14e23045b881d945e2b3f7f45e2581c5a6b6aa892ed25488aee57cb", size = 10335720, upload-time = "2025-08-08T19:47:37.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/d1d1b6e91ce4fcb54c2644a0f8f15bd4080b4e0d00db073b729fdea46a3a/memray-1.18.0-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:b59793bb1090f42270daad949ba0306226c67ef7deec2a59760df098370c16dc", size = 787047, upload-time = "2025-08-08T19:47:38.923Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/75/80a12fef1c8c7a43ab673e03896a22bc4b7cf9b2356d1529610f7770034d/memray-1.18.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c50382aa2b8f83d3892925c2599d55cda450ef2e180beebc6b8b7af90b92057", size = 766491, upload-time = "2025-08-08T19:47:40.064Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/84/67cd3ea04deb0017d039e1e56b5f8a50d1813de7512dae91c8d43ad52d8e/memray-1.18.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:84ece457908f1d718afcf7b47598910d89c9d351cb4fae63082e83147cad3b20", size = 7858824, upload-time = "2025-08-08T19:47:41.145Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/47/fd4531080499f81bac420cf7eb3967032c3493621429a73eace2a81e05d6/memray-1.18.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d1e208c4b2cf4b722c0c20c4078f693602fdc7e6260f91c555fe8ec258eb28e", size = 8120268, upload-time = "2025-08-08T19:47:43.295Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9c/f4545fc25d2c460e8ead91e7dc1677d261aa78ab3d6f72d5c05084797c7a/memray-1.18.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724295cd48d7b54ded94740dc427acad1b812f9e0f9358c32e42232c22d170de", size = 7494415, upload-time = "2025-08-08T19:47:44.645Z" },
+    { url = "https://files.pythonhosted.org/packages/44/62/6103c73945517fa4724e6012e57e57dc8678884d47b2874edcbc1c2ba0a8/memray-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e4738e7905d8abd3f320dd47e020a4393dad42f5b3b59802c0075cb8e5e8289f", size = 10325267, upload-time = "2025-08-08T19:47:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/52/d2/f7817b0eefddfc6420de50dac48b4fe0f68fd6ab7d32507521e82a2c67ad/memray-1.18.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:05815a0e8ce8a46affa32ccce97adc285eba5c9c1c7af9d8c7ea82a6c1e7e1b6", size = 801469, upload-time = "2025-08-08T19:47:47.802Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e5/3289debcea0f6cd4266173da650b068a7c6d5771929775b7c55c4090c268/memray-1.18.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a0437d0eb7de655910f33f05d7a864aafdd1275be5de72451449be2dcaf861", size = 778298, upload-time = "2025-08-08T19:47:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/95/f2da54c00644979cd5b94bb28caa93042499a397ca84ebadcb835f58d75e/memray-1.18.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4dd0677bf24d83f0cbf3d154e3bb0e0d89308d89b8e8bca4a6cd604564554a83", size = 7833756, upload-time = "2025-08-08T19:47:50.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/71/bdea11e72bcbb1c283446f0538ef8a732238e7eef38dec423f3d01022dae/memray-1.18.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec93a5c8cbc4b55bac49b208aceea33c064532cb91257659f0b848f4cb713e7", size = 8091609, upload-time = "2025-08-08T19:47:51.372Z" },
+    { url = "https://files.pythonhosted.org/packages/46/08/d1bdc6684cdb63323171290bbb40a1fb3239af1229f8a08d6a6bf5c94476/memray-1.18.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e4e3864510f62282ca9be24986aaa55cda1437fc5bfea70dbc8e4a55e870f43", size = 7492445, upload-time = "2025-08-08T19:47:52.659Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d5/ecfa0a06ab0f0bd060a5908edc839d81c8f37da671a69d19cf9f5773595e/memray-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:45c3ac6152915df66ff7df4602a82171b981efcfba89b132458808cd47a57f7f", size = 10258751, upload-time = "2025-08-08T19:47:53.955Z" },
 ]
 
 [[package]]
@@ -550,6 +726,22 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/31/4723d756b59344b643542936e37a31d1d3204bcdc42a7daa8ee9eb06fb50/psutil-7.1.0.tar.gz", hash = "sha256:655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2", size = 497660, upload-time = "2025-09-17T20:14:52.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/62/ce4051019ee20ce0ed74432dd73a5bb087a6704284a470bb8adff69a0932/psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13", size = 245242, upload-time = "2025-09-17T20:14:56.126Z" },
+    { url = "https://files.pythonhosted.org/packages/38/61/f76959fba841bf5b61123fbf4b650886dc4094c6858008b5bf73d9057216/psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5", size = 246682, upload-time = "2025-09-17T20:14:58.25Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7a/37c99d2e77ec30d63398ffa6a660450b8a62517cabe44b3e9bae97696e8d/psutil-7.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22e4454970b32472ce7deaa45d045b34d3648ce478e26a04c7e858a0a6e75ff3", size = 287994, upload-time = "2025-09-17T20:14:59.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/de/04c8c61232f7244aa0a4b9a9fbd63a89d5aeaf94b2fc9d1d16e2faa5cbb0/psutil-7.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c70e113920d51e89f212dd7be06219a9b88014e63a4cec69b684c327bc474e3", size = 291163, upload-time = "2025-09-17T20:15:01.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/58/c4f976234bf6d4737bc8c02a81192f045c307b72cf39c9e5c5a2d78927f6/psutil-7.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d4a113425c037300de3ac8b331637293da9be9713855c4fc9d2d97436d7259d", size = 293625, upload-time = "2025-09-17T20:15:04.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/87/157c8e7959ec39ced1b11cc93c730c4fb7f9d408569a6c59dbd92ceb35db/psutil-7.1.0-cp37-abi3-win32.whl", hash = "sha256:09ad740870c8d219ed8daae0ad3b726d3bf9a028a198e7f3080f6a1888b99bca", size = 244812, upload-time = "2025-09-17T20:15:07.462Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/b44c4f697276a7a95b8e94d0e320a7bf7f3318521b23de69035540b39838/psutil-7.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:57f5e987c36d3146c0dd2528cd42151cf96cd359b9d67cfff836995cc5df9a3d", size = 247965, upload-time = "2025-09-17T20:15:09.673Z" },
+    { url = "https://files.pythonhosted.org/packages/26/65/1070a6e3c036f39142c2820c4b52e9243246fcfc3f96239ac84472ba361e/psutil-7.1.0-cp37-abi3-win_arm64.whl", hash = "sha256:6937cb68133e7c97b6cc9649a570c9a18ba0efebed46d8c5dae4c07fa1b67a07", size = 244971, upload-time = "2025-09-17T20:15:12.262Z" },
+]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -669,6 +861,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -710,6 +915,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "textual"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify", "plugins"] },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/44/4b524b2f06e0fa6c4ede56a4e9af5edd5f3f83cf2eea5cb4fd0ce5bbe063/textual-6.1.0.tar.gz", hash = "sha256:cc89826ca2146c645563259320ca4ddc75d183c77afb7d58acdd46849df9144d", size = 1564786, upload-time = "2025-09-02T11:42:34.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/43/f91e041f239b54399310a99041faf33beae9a6e628671471d0fcd6276af4/textual-6.1.0-py3-none-any.whl", hash = "sha256:a3f5e6710404fcdc6385385db894699282dccf2ad50103cebc677403c1baadd5", size = 707840, upload-time = "2025-09-02T11:42:32.746Z" },
 ]
 
 [[package]]
@@ -788,6 +1009,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Fixes issue #76 where underscores and asterisks were incorrectly escaped inside `<code>` and `<pre>` blocks when those blocks were wrapped in container elements like `<div>`.

The issue was caused by the ancestor caching mechanism not properly checking the immediate parent element when determining whether to escape special characters.

## Changes
- **Fix core issue**: Updated `_process_text` to check both `ancestor_names` set AND immediate parent tag for code-like elements
- **Add test coverage**: Comprehensive tests for nested code/pre blocks in various wrapper elements
- **Type safety improvements**: Fixed `Callable[[str, ...], str]` -> `Callable[..., str]` throughout test files
- **Dev dependencies**: Added memray and psutil as required dev dependencies
- **Code cleanup**: Removed unnecessary conditionals from benchmark test files
- **Version bump**: Increment to v1.14.1

## Test Plan
- [x] All existing tests pass (2260 tests)
- [x] New tests specifically cover the bug scenarios from issue #76
- [x] Comprehensive test coverage for nested code/pre blocks in divs, sections, spans, etc.
- [x] Type checking passes with MyPy
- [x] Linting and formatting pass

## Before/After
**Before:**
```html
<div><pre>code_with_underscores</pre></div>
```
Incorrectly produced: `code\_with\_underscores` (escaped)

**After:**
```html
<div><pre>code_with_underscores</pre></div>
```
Correctly produces: `code_with_underscores` (not escaped)

Closes #76