### PR TITLE
Refactor code example for preprocessing options

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -105,10 +105,15 @@ for html in documents:
 from html_to_markdown import ConversionOptions, PreprocessingOptions, convert
 
 options = ConversionOptions(
-    preprocessing=PreprocessingOptions(enabled=True, preset="aggressive"),
+    ...
 )
 
-markdown = convert(scraped_html, options)
+preprocessing = PreprocessingOptions(
+    enabled=True,
+    preset="aggressive",
+)
+
+markdown = convert(scraped_html, options, preprocessing)
 ```
 
 ### Inline Image Extraction


### PR DESCRIPTION
Updated example code to include preprocessing options separately to match the API of `convert`:

```python
def convert(
    html: str,
    options: ConversionOptions | None = None,
    preprocessing: PreprocessingOptions | None = None,
) -> str:
    """Convert HTML to Markdown using the Rust backend."""
    if options is None and preprocessing is None:
        return _rust.convert(html, None)

    if options is None:
        options = ConversionOptions()
    if preprocessing is None:
        preprocessing = PreprocessingOptions()

    rust_options = _to_rust_options(options, preprocessing)
    return _rust.convert(html, rust_options)
```