### PR TITLE
Revert Cargo.toml change

### DIFF
--- a/packages/ruby/ext/html-to-markdown-rb/native/Cargo.toml
+++ b/packages/ruby/ext/html-to-markdown-rb/native/Cargo.toml
@@ -9,13 +9,10 @@ homepage = "https://github.com/kreuzberg-dev/html-to-markdown"
 documentation = "https://docs.rs/html-to-markdown-rs"
 readme = "README.md"
 rust-version = "1.85"
+lints.workspace = true
 description = "Ruby bindings (Magnus) for html-to-markdown - high-performance HTML to Markdown converter"
 keywords = ["html", "markdown", "ruby", "magnus", "bindings"]
 categories = ["api-bindings"]
-
-
-[lints]
-workspace = true
 
 [lib]
 name = "html_to_markdown_rb"


### PR DESCRIPTION
Ref: https://github.com/kreuzberg-dev/html-to-markdown/issues/181

This fix building the latest version of the ruby gem. Essentially a revert.

NB: I know very little about rust.