### PR TITLE
ci(ruby): prevents gem installation breakage

### DIFF
--- a/.github/workflows/ci-ruby.yaml
+++ b/.github/workflows/ci-ruby.yaml
@@ -106,3 +106,8 @@ jobs:
         working-directory: packages/ruby
         shell: pwsh
         run: ../../scripts/ci/ruby/run-rspec-windows.ps1
+
+      - name: Test gem installation
+        if: runner.os != 'Windows'
+        shell: bash
+        run: ./scripts/ci/ruby/run-gem-install.sh

--- a/scripts/ci/ruby/run-gem-install.sh
+++ b/scripts/ci/ruby/run-gem-install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pushd packages/ruby >/dev/null
+bundle exec rake clean
+ruby ../../scripts/prepare_ruby_gem.rb
+bundle exec rake build
+popd >/dev/null
+
+GEM_FILE=$(find packages/ruby/pkg -name "*.gem" -print -quit)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cp "$GEM_FILE" "$TMP_DIR/"
+cd "$TMP_DIR"
+gem install "$(basename "$GEM_FILE")" --no-document


### PR DESCRIPTION
This aims to prevent changes that could break the gem installation process, like in https://github.com/kreuzberg-dev/html-to-markdown/issues/181. It does this by adding a new CI step that actually installs the gem.

The mentioned issue was fixed by pinning the version in https://github.com/kreuzberg-dev/html-to-markdown/commit/106dfe68480657ee6742bc43257c8be1fcf5ce65, but without a test it's easy for this to regress.

This CI step helps catch any problems that would affect installation in the future.