### PR TITLE
fix: panic when using visitors with metadata extraction on minified HTML

### DIFF
--- a/crates/html-to-markdown/src/converter/visitor_hooks.rs
+++ b/crates/html-to-markdown/src/converter/visitor_hooks.rs
@@ -151,17 +151,23 @@ pub fn handle_visitor_element_end(
         is_inline: !is_block_level_element(tag_name),
     };
 
-    let element_content = &output[element_output_start..];
+    // When a child element's visitor returns Custom or Skip, the handler
+    // truncates `output` back to that child's `element_output_start`.  This
+    // can make the *parent* element's saved `element_output_start` stale —
+    // pointing past the end of the now-shorter `output`.  Clamp to prevent
+    // a panic on the string slice.
+    let safe_start = element_output_start.min(output.len());
+    let element_content = &output[safe_start..];
 
     let mut visitor = visitor_handle.borrow_mut();
     match visitor.visit_element_end(&node_ctx, element_content) {
         VisitResult::Continue => {}
         VisitResult::Custom(custom) => {
-            output.truncate(element_output_start);
+            output.truncate(safe_start);
             output.push_str(&custom);
         }
         VisitResult::Skip => {
-            output.truncate(element_output_start);
+            output.truncate(safe_start);
         }
         VisitResult::Error(err) => {
             if ctx.visitor_error.borrow().is_none() {

--- a/crates/html-to-markdown/tests/visitor_integration_test.rs
+++ b/crates/html-to-markdown/tests/visitor_integration_test.rs
@@ -921,3 +921,61 @@ fn test_convert_with_all_features_and_visitor() {
     // Verify markdown was produced
     assert!(!result.markdown.is_empty(), "Should produce markdown output");
 }
+
+/// Regression test: image visitor returning Custom with metadata extraction used to panic
+/// with an out-of-bounds slice.
+///
+/// When metadata extraction prepends a YAML frontmatter block to `output`, every element's
+/// saved `element_output_start` is offset by the frontmatter length.  If a child visitor
+/// then returns Custom and truncates the buffer, the parent's saved offset can point
+/// past `output.len()`.
+#[test]
+fn test_image_visitor_with_metadata_does_not_panic() {
+    #[derive(Debug)]
+    struct ImageVisitor;
+
+    impl HtmlVisitor for ImageVisitor {
+        fn visit_image(&mut self, _ctx: &NodeContext, _src: &str, _alt: &str, _title: Option<&str>) -> VisitResult {
+            VisitResult::Custom("![img](rewritten.png)".to_string())
+        }
+    }
+
+    let html = r#"<html><head><meta name="description" content="x"></head><body><p><img src="a.png" alt="a"></p></body></html>"#;
+    let options = ConversionOptions {
+        extract_metadata: true,
+        ..Default::default()
+    };
+
+    let result = convert_with_visitor(html, Some(options), Some(Rc::new(RefCell::new(ImageVisitor))));
+    assert!(result.is_ok(), "conversion panicked or errored: {:?}", result.err());
+}
+
+/// Regression test: visit_element_end returning Custom/Skip with metadata extraction used
+/// to produce stale parent offsets and either panic or silently drop subsequent content.
+#[test]
+fn test_element_end_replacement_with_metadata_preserves_subsequent_content() {
+    #[derive(Debug)]
+    struct FigureReplacingVisitor;
+
+    impl HtmlVisitor for FigureReplacingVisitor {
+        fn visit_element_end(&mut self, ctx: &NodeContext, _content: &str) -> VisitResult {
+            if ctx.tag_name == "figure" {
+                return VisitResult::Custom("[figure]".to_string());
+            }
+            VisitResult::Continue
+        }
+    }
+
+    let html = r#"<html><head><meta name="description" content="x"></head><body><figure><img src="a.png"></figure><p>after</p></body></html>"#;
+    let options = ConversionOptions {
+        extract_metadata: true,
+        ..Default::default()
+    };
+
+    let result = convert_with_visitor(html, Some(options), Some(Rc::new(RefCell::new(FigureReplacingVisitor))));
+    assert!(result.is_ok(), "conversion panicked or errored: {:?}", result.err());
+    assert!(
+        result.unwrap().contains("after"),
+        "content after replaced element should not be lost"
+    );
+}


### PR DESCRIPTION
I was converting blog HTML using metadata extraction and aggressive preprocessing, combined with an image visitor that rewrites URLs by returning Custom from visit_image.

On minified HTML this panicked with an out-of-bounds slice. The issue is that when metadata extraction is enabled, a YAML frontmatter block gets prepended to the output before any body content is processed. Each element records its start offset in the output buffer at open time, but by the time visit_element_end runs, those offsets are stale. When the image visitor returns Custom and the handler tries to truncate output back to that saved offset, the offset is past the end of the buffer.

Clamping the saved offset to `output.len()` before slicing stops the panic. I'm not sure this is the right fix though. If there's a better approach I'm happy to try it