### PR TITLE
docs: fix the div blocks as they were breaking

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for considering a contribution to html-to-markdown. Every fix, feature, and documentation improvement helps.
+Thanks for considering a contribution to html-to-markdown. Every fix, feature, and documentation improvement helps us to make it better.
 
 ## Ways to contribute
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,37 +30,25 @@ Convert HTML to Markdown, Djot, or plain text. One Rust core, 12 native language
 
 - :material-lightning-bolt:{ .lg .middle } **150–280 MB/s throughput**
 
----
-
     Rust-native parsing and a single-pass DOM walk. 10–80x faster than pure-language alternatives. No JVM, no interpreter overhead.
 
 - :material-translate:{ .lg .middle } **12 language bindings**
-
----
 
     Rust, Python, TypeScript, Go, Ruby, PHP, Java, C#, Elixir, R, C, and WebAssembly. All wrap the same core — no separate conversion logic per language.
 
 - :material-format-text:{ .lg .middle } **Three output formats**
 
----
-
     Markdown (CommonMark), Djot, and plain text. Switch with `output_format`. All formatting options apply to every format.
 
 - :material-tag-multiple:{ .lg .middle } **Metadata extraction**
-
----
 
     Title, description, Open Graph, Twitter Card, JSON-LD, links, and images — all in one pass. Enable with `extract_metadata: true`.
 
 - :material-table:{ .lg .middle } **Table extraction**
 
----
-
     Every `<table>` lands in `result.tables` as a structured cell grid with colspan, rowspan, and header data, plus a rendered Markdown string.
 
 - :material-filter:{ .lg .middle } **Visitor pattern**
-
----
 
     40 callbacks to rewrite links, filter elements, or emit custom Markdown for any HTML tag. Zero overhead when not used.
 
@@ -74,15 +62,11 @@ Convert HTML to Markdown, Djot, or plain text. One Rust core, 12 native language
 
 - :material-download:{ .lg .middle } **Installation**
 
----
-
     Package manager commands for all 12 languages, plus Cargo feature flags for Rust.
 
     [:octicons-arrow-right-24: Installation](installation.md)
 
 - :material-play:{ .lg .middle } **Usage**
-
----
 
     Convert HTML, read result fields, extract metadata, and work with document structure.
 
@@ -90,15 +74,11 @@ Convert HTML to Markdown, Djot, or plain text. One Rust core, 12 native language
 
 - :material-cog:{ .lg .middle } **Configuration**
 
----
-
     All 34 options with types, defaults, and descriptions. Output formats, preprocessing, link and image handling.
 
     [:octicons-arrow-right-24: Configuration](configuration.md)
 
 - :material-table:{ .lg .middle } **Table Extraction**
-
----
 
     Access cell-level grid data with colspan, rowspan, and header info alongside rendered Markdown.
 
@@ -106,15 +86,11 @@ Convert HTML to Markdown, Djot, or plain text. One Rust core, 12 native language
 
 - :material-filter:{ .lg .middle } **Visitor Pattern**
 
----
-
     Filter, rewrite, or replace any element during conversion with 40 typed callbacks.
 
     [:octicons-arrow-right-24: Visitor](visitor.md)
 
 - :material-api:{ .lg .middle } **API Reference**
-
----
 
     Every public type: `ConversionResult`, `DocumentNode`, `HtmlMetadata`, `TableData`, `InlineImage`, and more.
 


### PR DESCRIPTION
This pull request makes minor improvements to the documentation for clarity and formatting. The main change is a small wording update in the contributing guide, and the rest of the changes are formatting adjustments to the features and navigation sections of the documentation homepage.

Documentation improvements:

* Updated the introductory sentence in `docs/contributing.md` for clarity by rephrasing the second sentence.

Documentation formatting:

* Reformatted the feature descriptions and navigation sections in `docs/index.md` by removing unnecessary horizontal rules for a cleaner appearance. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L33-L64) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L77-L118)