### PR TITLE
docs: fix Python ConversionResult attribute access

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ See the **[Installation Guide](https://docs.html-to-markdown.kreuzberg.dev/getti
 from html_to_markdown import convert
 
 result = convert("<h1>Hello</h1><p>World</p>")
-print(result["content"])        # # Hello\n\nWorld
-print(result["metadata"])       # title, links, headings, …
+print(result.content)        # # Hello\n\nWorld
+print(result.metadata)       # title, links, headings, …
 ```
 
 ```typescript

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ println!("{}", result.content.unwrap_or_default());
 from html_to_markdown import convert
 
 result = convert("<h1>Hello</h1><p>This is <strong>fast</strong>!</p>")
-print(result["content"])
+print(result.content)
 # # Hello
 #
 # This is **fast**!

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -53,7 +53,7 @@ let markdown = result.content.unwrap_or_default();
 from html_to_markdown import convert
 
 result = convert("<h1>Hello</h1><p>World</p>")
-markdown = result["content"]
+markdown = result.content
 # "# Hello\n\nWorld"
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -88,8 +88,8 @@ markdown, metadata = convert_with_metadata(html)
 
 # v3
 result = convert(html)
-markdown = result["content"]
-metadata = result["metadata"]
+markdown = result.content
+metadata = result.metadata
 ```
 
 ### TypeScript

--- a/docs/snippets/python/getting-started/basic_usage.md
+++ b/docs/snippets/python/getting-started/basic_usage.md
@@ -3,5 +3,5 @@ from html_to_markdown import convert
 
 html = "<h1>Hello</h1><p>This is <strong>fast</strong>!</p>"
 result = convert(html)
-markdown = result["content"]
+markdown = result.content
 ```

--- a/docs/snippets/python/getting-started/with_options.md
+++ b/docs/snippets/python/getting-started/with_options.md
@@ -7,5 +7,5 @@ options = ConversionOptions(
     list_indent_width=2,
 )
 result = convert(html, options)
-markdown = result["content"]
+markdown = result.content
 ```

--- a/docs/snippets/python/metadata/basic_extraction.md
+++ b/docs/snippets/python/metadata/basic_extraction.md
@@ -3,13 +3,8 @@ from html_to_markdown import ConversionOptions, convert
 
 options = ConversionOptions(
     extract_metadata=True,
-    extract_headers=True,
-    extract_links=True,
-    extract_images=True,
-    extract_structured_data=True,
-    max_structured_data_size=100000,
 )
 result = convert(html, options)
-markdown = result["content"]
-metadata = result["metadata"]
+markdown = result.content
+metadata = result.metadata
 ```

--- a/docs/snippets/python/table-extraction/basic_extraction.md
+++ b/docs/snippets/python/table-extraction/basic_extraction.md
@@ -1,5 +1,5 @@
 ```python
-from html_to_markdown import ConversionOptions, convert
+from html_to_markdown import convert
 
 html = """
 <table>
@@ -9,11 +9,10 @@ html = """
 </table>
 """
 
-options = ConversionOptions(extract_tables=True)
-result = convert(html, options)
+result = convert(html)
 
-for table in result["tables"]:
-    for i, row in enumerate(table["cells"]):
-        prefix = "Header" if table["is_header_row"][i] else "Row"
-        print(f"  {prefix}: {row}")
+for table in result.tables:
+    for cell in table.grid.cells:
+        prefix = "Header" if cell.is_header else "Cell"
+        print(f"  {prefix}: {cell.content}")
 ```

--- a/docs/snippets/python/visitor/basic_visitor.md
+++ b/docs/snippets/python/visitor/basic_visitor.md
@@ -12,5 +12,5 @@ class CustomVisitor:
 
 options = ConversionOptions(visitor=CustomVisitor())
 result = convert(html, options)
-markdown = result["content"]
+markdown = result.content
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,8 +162,8 @@ Enable `include_document_structure` to get a parsed tree of the document's struc
 
     options = ConversionOptions(include_document_structure=True)
     result = convert("<h1>Title</h1><p>Paragraph</p>", options)
-    doc = result["document"]
-    for node in doc["nodes"]:
+    doc = result.document
+    for node in doc.nodes:
         print(node)
     ```
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -97,7 +97,7 @@ from html_to_markdown import convert
 
 html = "<h1>Hello</h1><p>This is <strong>fast</strong>!</p>"
 result = convert(html)
-markdown = result["content"]
+markdown = result.content
 ```
 
 
@@ -112,7 +112,7 @@ options = ConversionOptions(
     list_indent_width=2,
 )
 result = convert(html, options)
-markdown = result["content"]
+markdown = result.content
 ```
 
 
@@ -123,18 +123,18 @@ markdown = result["content"]
 
 **`convert(html: str, options?: ConversionOptions, visitor?: object) -> ConversionResult`**
 
-Converts HTML to Markdown. Returns a `ConversionResult` dict with all results in a single call.
+Converts HTML to Markdown. Returns a `ConversionResult` object with all results in a single call.
 
 ```python
 from html_to_markdown import convert, ConversionOptions
 
 result = convert(html)
-markdown = result["content"]           # Converted Markdown string
-metadata = result["metadata"]          # Metadata (when extract_metadata=True)
-tables   = result["tables"]            # Structured table data (when extract_tables=True)
-document = result["document"]          # Document-level info
-images   = result["images"]            # Extracted images
-warnings = result["warnings"]          # Any conversion warnings
+markdown = result.content           # Converted Markdown string
+metadata = result.metadata          # Metadata (when extract_metadata=True)
+tables   = result.tables            # Structured table data
+document = result.document          # Document-level info
+images   = result.images            # Extracted images
+warnings = result.warnings          # Any conversion warnings
 ```
 
 
@@ -236,12 +236,12 @@ from html_to_markdown import convert, ConversionOptions
 html = '<h1>Article</h1><img src="test.jpg" alt="test">'
 result = convert(html, ConversionOptions(extract_metadata=True))
 
-print(result["content"])                          # Converted Markdown
-print(result["metadata"]["document"]["title"])    # Document title
-print(result["metadata"]["headers"])              # All h1-h6 elements
-print(result["metadata"]["links"])                # All hyperlinks
-print(result["metadata"]["images"])               # All images with alt text
-print(result["metadata"]["structured_data"])      # JSON-LD, Microdata, RDFa
+print(result.content)                          # Converted Markdown
+print(result.metadata.document.title)          # Document title
+print(result.metadata.headers)                 # All h1-h6 elements
+print(result.metadata.links)                   # All hyperlinks
+print(result.metadata.images)                  # All images with alt text
+print(result.metadata.structured_data)         # JSON-LD, Microdata, RDFa
 ```
 
 
@@ -285,7 +285,7 @@ class MyVisitor:
 
 html = '<a href="https://old-cdn.com/file.pdf">Download</a>'
 result = convert(html, visitor=MyVisitor())
-markdown = result["content"]
+markdown = result.content
 ```
 
 

--- a/readme_templates/partials/_api_reference.md
+++ b/readme_templates/partials/_api_reference.md
@@ -3,18 +3,18 @@
 {% if language == 'python' %}
 **`convert(html: str, options?: ConversionOptions, visitor?: object) -> ConversionResult`**
 
-Converts HTML to Markdown. Returns a `ConversionResult` dict with all results in a single call.
+Converts HTML to Markdown. Returns a `ConversionResult` object with all results in a single call.
 
 ```python
 from html_to_markdown import convert, ConversionOptions
 
 result = convert(html)
-markdown = result["content"]           # Converted Markdown string
-metadata = result["metadata"]          # Metadata (when extract_metadata=True)
-tables   = result["tables"]            # Structured table data (when extract_tables=True)
-document = result["document"]          # Document-level info
-images   = result["images"]            # Extracted images
-warnings = result["warnings"]          # Any conversion warnings
+markdown = result.content           # Converted Markdown string
+metadata = result.metadata          # Metadata (when extract_metadata=True)
+tables   = result.tables            # Structured table data
+document = result.document          # Document-level info
+images   = result.images            # Extracted images
+warnings = result.warnings          # Any conversion warnings
 ```
 
 {% elif language == 'typescript' %}

--- a/readme_templates/partials/_metadata_extraction.md
+++ b/readme_templates/partials/_metadata_extraction.md
@@ -20,12 +20,12 @@ from html_to_markdown import convert, ConversionOptions
 html = '<h1>Article</h1><img src="test.jpg" alt="test">'
 result = convert(html, ConversionOptions(extract_metadata=True))
 
-print(result["content"])                          # Converted Markdown
-print(result["metadata"]["document"]["title"])    # Document title
-print(result["metadata"]["headers"])              # All h1-h6 elements
-print(result["metadata"]["links"])                # All hyperlinks
-print(result["metadata"]["images"])               # All images with alt text
-print(result["metadata"]["structured_data"])      # JSON-LD, Microdata, RDFa
+print(result.content)                          # Converted Markdown
+print(result.metadata.document.title)          # Document title
+print(result.metadata.headers)                 # All h1-h6 elements
+print(result.metadata.links)                   # All hyperlinks
+print(result.metadata.images)                  # All images with alt text
+print(result.metadata.structured_data)         # JSON-LD, Microdata, RDFa
 ```
 
 {% elif language == 'typescript' %}

--- a/readme_templates/partials/_visitor_pattern.md
+++ b/readme_templates/partials/_visitor_pattern.md
@@ -32,7 +32,7 @@ class MyVisitor:
 
 html = '<a href="https://old-cdn.com/file.pdf">Download</a>'
 result = convert(html, visitor=MyVisitor())
-markdown = result["content"]
+markdown = result.content
 ```
 
 {% elif language == 'typescript' %}

--- a/scripts/readme_templates/partials/_api_reference.md.jinja
+++ b/scripts/readme_templates/partials/_api_reference.md.jinja
@@ -3,18 +3,18 @@
 {% if language == 'python' %}
 **`convert(html: str, options?: ConversionOptions, visitor?: object) -> ConversionResult`**
 
-Converts HTML to Markdown. Returns a `ConversionResult` dict with all results in a single call.
+Converts HTML to Markdown. Returns a `ConversionResult` object with all results in a single call.
 
 ```python
 from html_to_markdown import convert, ConversionOptions
 
 result = convert(html)
-markdown = result["content"]           # Converted Markdown string
-metadata = result["metadata"]          # Metadata (when extract_metadata=True)
-tables   = result["tables"]            # Structured table data (when extract_tables=True)
-document = result["document"]          # Document-level info
-images   = result["images"]            # Extracted images
-warnings = result["warnings"]          # Any conversion warnings
+markdown = result.content           # Converted Markdown string
+metadata = result.metadata          # Metadata (when extract_metadata=True)
+tables   = result.tables            # Structured table data
+document = result.document          # Document-level info
+images   = result.images            # Extracted images
+warnings = result.warnings          # Any conversion warnings
 ```
 
 {% elif language == 'typescript' %}

--- a/scripts/readme_templates/partials/_metadata_extraction.md.jinja
+++ b/scripts/readme_templates/partials/_metadata_extraction.md.jinja
@@ -18,12 +18,12 @@ from html_to_markdown import convert, ConversionOptions
 html = '<h1>Article</h1><img src="test.jpg" alt="test">'
 result = convert(html, ConversionOptions(extract_metadata=True))
 
-print(result["content"])                          # Converted Markdown
-print(result["metadata"]["document"]["title"])    # Document title
-print(result["metadata"]["headers"])              # All h1-h6 elements
-print(result["metadata"]["links"])                # All hyperlinks
-print(result["metadata"]["images"])               # All images with alt text
-print(result["metadata"]["structured_data"])      # JSON-LD, Microdata, RDFa
+print(result.content)                          # Converted Markdown
+print(result.metadata.document.title)          # Document title
+print(result.metadata.headers)                 # All h1-h6 elements
+print(result.metadata.links)                   # All hyperlinks
+print(result.metadata.images)                  # All images with alt text
+print(result.metadata.structured_data)         # JSON-LD, Microdata, RDFa
 ```
 
 {% elif language == 'typescript' %}

--- a/scripts/readme_templates/partials/_visitor_pattern.md.jinja
+++ b/scripts/readme_templates/partials/_visitor_pattern.md.jinja
@@ -30,7 +30,7 @@ class MyVisitor:
 
 html = '<a href="https://old-cdn.com/file.pdf">Download</a>'
 result = convert(html, visitor=MyVisitor())
-markdown = result["content"]
+markdown = result.content
 ```
 
 {% elif language == 'typescript' %}

--- a/skills/html-to-markdown/SKILL.md
+++ b/skills/html-to-markdown/SKILL.md
@@ -150,7 +150,7 @@ from html_to_markdown import convert
 
 html = "<h1>Hello World</h1><p>This is a paragraph.</p>"
 result = convert(html)
-print(result["content"])
+print(result.content)
 # Output: # Hello World\n\nThis is a paragraph.\n
 ```
 
@@ -198,10 +198,10 @@ All languages return the same data structure (as a dict, object, or struct).
 |-------|-----------|--------|------------|-------------|
 | `content` | `Option<String>` | `str \| None` | `string \| null` | Converted text (Markdown/Djot/plain). `None` only in extraction-only mode. |
 | `document` | `Option<DocumentStructure>` | `None` (not yet wired) | `null` (not yet wired) | Structured document tree when `include_document_structure=true` |
-| `metadata` | `HtmlMetadata` | `dict \| None` | JSON object or null | Extracted HTML metadata (title, OG, headers, links, images, structured data). Requires `metadata` feature. |
-| `tables` | `Vec<TableData>` | `list[dict]` | `array` | Extracted tables with `grid` (structured cells) and `markdown` fields |
+| `metadata` | `HtmlMetadata` | `HtmlMetadata \| None` | JSON object or null | Extracted HTML metadata (title, OG, headers, links, images, structured data). Requires `metadata` feature. |
+| `tables` | `Vec<TableData>` | `list[TableData]` | `array` | Extracted tables with `grid` (structured cells) and `markdown` fields |
 | `images` | `Vec<InlineImage>` | `list` | `array` | Extracted inline images (data URIs, SVGs). Requires `inline-images` feature. |
-| `warnings` | `Vec<ProcessingWarning>` | `list[dict]` | `array` | Non-fatal processing warnings with `message` and `kind` fields |
+| `warnings` | `Vec<ProcessingWarning>` | `list[ProcessingWarning]` | `array` | Non-fatal processing warnings with `message` and `kind` fields |
 
 ## Configuration
 
@@ -242,7 +242,7 @@ preprocessing = PreprocessingOptions(
 )
 
 result = convert(html, options, preprocessing)
-print(result["content"])
+print(result.content)
 ```
 
 ### TypeScript / Node.js (object)
@@ -309,28 +309,28 @@ html = """
 </html>
 """
 result = convert(html)
-meta = result["metadata"]
+meta = result.metadata
 
 # Document-level metadata
-print(meta["document"]["title"])           # "My Article"
-print(meta["document"]["description"])     # "An article"
-print(meta["document"]["language"])        # "en"
-print(meta["document"]["open_graph"])      # {"title": "OG Title"}
+print(meta.document.title)           # "My Article"
+print(meta.document.description)     # "An article"
+print(meta.document.language)        # "en"
+print(meta.document.open_graph)      # {"title": "OG Title"}
 
 # Headers
-print(meta["headers"][0]["level"])         # 1
-print(meta["headers"][0]["text"])          # "Main Heading"
+print(meta.headers[0].level)         # 1
+print(meta.headers[0].text)          # "Main Heading"
 
 # Links
-print(meta["links"][0]["href"])            # "https://example.com"
-print(meta["links"][0]["link_type"])       # "external"
+print(meta.links[0].href)            # "https://example.com"
+print(meta.links[0].link_type)       # "external"
 
 # Images
-print(meta["images"][0]["alt"])            # "A photo"
-print(meta["images"][0]["image_type"])     # "external"
+print(meta.images[0].alt)            # "A photo"
+print(meta.images[0].image_type)     # "external"
 ```
 
-All metadata is available in `result["metadata"]` (Python), `result.metadata` (Go/Ruby/Elixir), `JSON.parse(convert(html)).metadata` (TypeScript), or `result.metadata` (Rust) from the single `convert()` call.
+All metadata is available in `result.metadata` (Python/Rust/Go/Ruby/Elixir) or `JSON.parse(convert(html)).metadata` (TypeScript) from the single `convert()` call.
 
 ## Document Structure Extraction
 
@@ -340,7 +340,7 @@ Enable `include_document_structure=True` to get a structured semantic tree:
 from html_to_markdown import convert, ConversionOptions
 
 result = convert(html, ConversionOptions(include_document_structure=True))
-doc = result["document"]  # DocumentStructure with nodes array
+doc = result.document  # DocumentStructure with nodes array
 # Each node has: id, content (node_type + fields), parent, children, annotations
 ```
 
@@ -348,9 +348,9 @@ Node types include: `heading`, `paragraph`, `list`, `list_item`, `table`, `image
 
 ## Common Pitfalls
 
-1. **`convert()` returns a result object, not a string.** Access `.content` (Rust/Python dict key) or `JSON.parse()` the return (Node.js) to get the Markdown string.
+1. **`convert()` returns a result object, not a string.** Access `.content` (Rust/Python) or `JSON.parse()` the return (Node.js) to get the Markdown string.
 2. **Node.js `convert()` returns a JSON string.** Always `JSON.parse(convert(html))` — the native NAPI binding returns serialized JSON to avoid type conversion overhead.
-3. **Python `convert()` returns an `ExtractionResult` dict.** Use `result["content"]` for the Markdown text, not `str(result)`.
+3. **Python `convert()` returns a `ConversionResult` object.** Use `result.content` for the Markdown text, not `str(result)` or `result["content"]`.
 4. **Rust builder pattern required.** Use `ConversionOptions::builder().field(value).build()` — direct struct construction omits future fields silently.
 5. **`metadata` requires the `metadata` feature.** In Rust, the `metadata` feature is included in `default`. In bindings (Python, Node, etc.), metadata is always available.
 6. **Python `PreprocessingOptions` is a separate parameter.** Pass it as the second argument to `convert()`, not inside `ConversionOptions`.


### PR DESCRIPTION
## summary                                                                                
  
  - replace all `result["content"]`/`result["metadata"]` dict-style access with  `result.content`/`result.metadata` attribute access across every Python example
  - fix nested metadata access: `result["metadata"]["headers"]` → `result.metadata.headers`, `result["metadata"]["document"]["title"]` → `result.metadata.document.title`, etc.
  - remove non-existent `ConversionOptions` params from Python snippets:                    
    `extract_headers`, `extract_links`, `extract_structured_data`, `extract_tables`,        
    `max_structured_data_size` (these don't exist on `ConversionOptions`)                   
  - update type column in SKILL.md table: `dict | None` → `HtmlMetadata | None`,  `list[dict]` → `list[TableData]`                                                        
  - update Common Pitfalls to correctly name `ConversionResult` (was `ExtractionResult`)    
                                                                                        
  
  ## test                                                                      
                                                            
  - [ ] verify `python -c "from html_to_markdown import convert; r = convert('<h1>Hi</h1>');
   print(r.content)"` works
  - [ ] confirm `result.metadata.document.title` access works with `extract_metadata=True`  
                                                                                            
  closes #307