### PR TITLE
fix(java): fix FFI broken,.. native libs bundled under wrong JAR path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Java FFI broken on all platforms** (#315) — native libraries were bundled into the JAR under `natives/{platform}/` by the publish script, but `NativeLib.java` looked for them at `native/{platform}/`. Every release since the FFI was introduced shipped a non-functional JAR. Fixed `copy-native-libs.sh` to write into the correct `natives/` resource directory and added an explicit `mkdir -p` before each copy for portability.
+
 ## [3.2.6] - 2026-04-20
 
 ### Fixed

--- a/scripts/publish/java/copy-native-libs.sh
+++ b/scripts/publish/java/copy-native-libs.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # so they can be bundled in the published JAR
 
 artifacts_dir="${1:?ARTIFACTS_DIR is required (e.g. java-ffi-artifacts)}"
-resources_dir="packages/java/src/main/resources/native"
+resources_dir="packages/java/src/main/resources/natives"
 
 echo "Copying native libraries from ${artifacts_dir} to ${resources_dir}"
 
@@ -21,7 +21,8 @@ for platform_dir in "${artifacts_dir}"/*; do
   if [[ -d "${platform_dir}" ]]; then
     platform_name="$(basename "${platform_dir}")"
     echo "  Copying ${platform_name}..."
-    cp -r "${platform_dir}/native" "${resources_dir}/${platform_name}/"
+    mkdir -p "${resources_dir}/${platform_name}"
+    cp -r "${platform_dir}/native/." "${resources_dir}/${platform_name}/"
   fi
 done
 


### PR DESCRIPTION
 ## fix                                                                                    
                                                                                            
  - Rename the target resource directory in `copy-native-libs.sh` from `native` to `natives` so it matches what `NativeLib.java` expects.
  - Add an explicit `mkdir -p` before each `cp` so the platform  subdirectory is always created reliably (the old `cp -r src dest/`
    with a trailing slash on a non-existent directory is not portable).                     
                                                                                            
  ## testing                                                                                
                                                                                            
  The fix is in the publish-time packaging script. To verify locally, run `scripts/publish/java/build-ffi.sh` for your platform into a temp dir, then run `copy-native-libs.sh` against it and confirm the library lands at `packages/java/src/main/resources/natives/{platform}/libhtml_to_markdown_ffi.{so,  dylib,dll}`.  
  

closes #315    