### PR TITLE
fix(ruby): fix TypeError on every convert() call,.. options type mismatch and wrong return type 

### DIFF
--- a/packages/csharp/HtmlToMarkdown/HtmlToMarkdownRs.cs
+++ b/packages/csharp/HtmlToMarkdown/HtmlToMarkdownRs.cs
@@ -51,7 +51,9 @@ public static class HtmlToMarkdownRs
             optionsHandle
         );
         if (result == IntPtr.Zero)
-        { var err = GetLastError(); if (err.Code != 0)
+        {
+            var err = GetLastError();
+            if (err.Code != 0)
             {
                 throw err;
             }

--- a/packages/python/html_to_markdown/api.py
+++ b/packages/python/html_to_markdown/api.py
@@ -135,4 +135,4 @@ def _to_rust_conversion_options(value: ConversionOptions | None) -> _rust.Conver
 def convert(html: str, options: ConversionOptions | None = None, visitor: str | None = None) -> ConversionResult:
     """Convert HTML to Markdown, returning a [`ConversionResult`] with content, metadata, images."""
     _rust_options = _to_rust_conversion_options(options)
-    return _rust.convert(html, _rust_options, visitor)  # type: ignore[arg-type]
+    return _rust.convert(html, _rust_options, visitor)

--- a/packages/ruby/Gemfile.lock
+++ b/packages/ruby/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     csv (3.3.5)
     diff-lcs (1.6.2)
     ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     fileutils (1.8.0)
     json (2.19.4)
     language_server-protocol (3.17.0.5)
@@ -106,6 +107,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   html-to-markdown!
@@ -124,6 +126,7 @@ CHECKSUMS
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   html-to-markdown (3.2.6)
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac

--- a/packages/ruby/ext/html_to_markdown_rb/src/lib.rs
+++ b/packages/ruby/ext/html_to_markdown_rb/src/lib.rs
@@ -2799,18 +2799,7 @@ pub fn convert(
         }
         _ => None,
     };
-    let options_core: Option<html_to_markdown_rs::ConversionOptions> = options
-        .as_deref()
-        .filter(|s| *s != "nil")
-        .map(|s| {
-            serde_json::from_str(s).map_err(|e| {
-                magnus::Error::new(
-                    unsafe { magnus::Ruby::get_unchecked() }.exception_runtime_error(),
-                    e.to_string(),
-                )
-            })
-        })
-        .transpose()?;
+    let options_core: Option<html_to_markdown_rs::ConversionOptions> = options.map(Into::into);
     html_to_markdown_rs::convert(&html, options_core, visitor)
         .map(|val| val.into())
         .map_err(|e| {
@@ -2832,7 +2821,7 @@ fn nodecontext_to_rb_hash(ctx: &html_to_markdown_rs::visitor::NodeContext) -> ma
     h.aset(ruby.to_symbol("is_inline"), ctx.is_inline).ok();
     h.aset(
         ruby.to_symbol("parent_tag"),
-        ctx.parent_tag.as_deref().map(|s| magnus::Value::from(ruby.str_new(s))),
+        ctx.parent_tag.as_deref().map(|s| ruby.str_new(s)),
     )
     .ok();
     let attrs = ruby.hash_new();
@@ -2866,7 +2855,7 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
             return html_to_markdown_rs::VisitResult::Continue;
         }
         let result: Result<magnus::Value, magnus::Error> =
-            magnus::method::Method::funcall(self.rb_obj, "visit_element_start", (nodecontext_to_rb_hash(_ctx),));
+            self.rb_obj.funcall("visit_element_start", (nodecontext_to_rb_hash(_ctx),));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -2890,11 +2879,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_element_end",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_output)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_element_end", (nodecontext_to_rb_hash(_ctx), _output));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -2914,11 +2900,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_text",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_text", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -2944,16 +2927,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_link",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_href),
-                magnus::RString::new(_text),
-                magnus::RString::new(_title),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_link", (nodecontext_to_rb_hash(_ctx), _href, _text, _title));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -2979,16 +2954,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_image",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_src),
-                magnus::RString::new(_alt),
-                magnus::RString::new(_title),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_image", (nodecontext_to_rb_hash(_ctx), _src, _alt, _title));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3014,16 +2981,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_heading",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::Value::from(_level),
-                magnus::RString::new(_text),
-                magnus::RString::new(_id),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_heading", (nodecontext_to_rb_hash(_ctx), _level, _text, _id));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3048,15 +3007,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_code_block",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_lang),
-                magnus::RString::new(_code),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_code_block", (nodecontext_to_rb_hash(_ctx), _lang, _code));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3080,11 +3032,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_code_inline",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_code)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_code_inline", (nodecontext_to_rb_hash(_ctx), _code));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3110,16 +3059,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_list_item",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::Value::from(_ordered),
-                magnus::RString::new(_marker),
-                magnus::RString::new(_text),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_list_item", (nodecontext_to_rb_hash(_ctx), _ordered, _marker, _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3143,11 +3084,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_list_start",
-            (nodecontext_to_rb_hash(_ctx), magnus::Value::from(_ordered)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_list_start", (nodecontext_to_rb_hash(_ctx), _ordered));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3172,15 +3110,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_list_end",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::Value::from(_ordered),
-                magnus::RString::new(_output),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_list_end", (nodecontext_to_rb_hash(_ctx), _ordered, _output));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3201,7 +3132,7 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
             return html_to_markdown_rs::VisitResult::Continue;
         }
         let result: Result<magnus::Value, magnus::Error> =
-            magnus::method::Method::funcall(self.rb_obj, "visit_table_start", (nodecontext_to_rb_hash(_ctx),));
+            self.rb_obj.funcall("visit_table_start", (nodecontext_to_rb_hash(_ctx),));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3226,15 +3157,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_table_row",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::Value::from(_cells),
-                magnus::Value::from(_is_header),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_table_row", (nodecontext_to_rb_hash(_ctx), _cells.to_vec(), _is_header));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3258,11 +3182,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_table_end",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_output)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_table_end", (nodecontext_to_rb_hash(_ctx), _output));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3287,15 +3208,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_blockquote",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_content),
-                magnus::Value::from(_depth),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_blockquote", (nodecontext_to_rb_hash(_ctx), _content, _depth));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3319,11 +3233,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_strong",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_strong", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3347,11 +3258,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_emphasis",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_emphasis", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3375,11 +3283,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_strikethrough",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_strikethrough", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3403,11 +3308,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_underline",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_underline", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3431,11 +3333,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_subscript",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_subscript", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3459,11 +3358,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_superscript",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_superscript", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3483,11 +3379,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_mark",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_mark", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3508,7 +3401,7 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
             return html_to_markdown_rs::VisitResult::Continue;
         }
         let result: Result<magnus::Value, magnus::Error> =
-            magnus::method::Method::funcall(self.rb_obj, "visit_line_break", (nodecontext_to_rb_hash(_ctx),));
+            self.rb_obj.funcall("visit_line_break", (nodecontext_to_rb_hash(_ctx),));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3529,7 +3422,7 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
             return html_to_markdown_rs::VisitResult::Continue;
         }
         let result: Result<magnus::Value, magnus::Error> =
-            magnus::method::Method::funcall(self.rb_obj, "visit_horizontal_rule", (nodecontext_to_rb_hash(_ctx),));
+            self.rb_obj.funcall("visit_horizontal_rule", (nodecontext_to_rb_hash(_ctx),));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3554,15 +3447,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_custom_element",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_tag_name),
-                magnus::RString::new(_html),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_custom_element", (nodecontext_to_rb_hash(_ctx), _tag_name, _html));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3588,11 +3474,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_definition_list_start",
-            (nodecontext_to_rb_hash(_ctx),),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_definition_list_start", (nodecontext_to_rb_hash(_ctx),));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3616,11 +3499,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_definition_term",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_definition_term", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3647,11 +3527,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_definition_description",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_definition_description", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3678,11 +3555,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_definition_list_end",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_output)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_definition_list_end", (nodecontext_to_rb_hash(_ctx), _output));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3707,15 +3581,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_form",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_action),
-                magnus::RString::new(_method),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_form", (nodecontext_to_rb_hash(_ctx), _action, _method));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3741,16 +3608,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_input",
-            (
-                nodecontext_to_rb_hash(_ctx),
-                magnus::RString::new(_input_type),
-                magnus::RString::new(_name),
-                magnus::RString::new(_value),
-            ),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_input", (nodecontext_to_rb_hash(_ctx), _input_type, _name.map(|s| s.to_string()), _value.map(|s| s.to_string())));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3774,11 +3633,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_button",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_button", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3802,11 +3658,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_audio",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_src)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_audio", (nodecontext_to_rb_hash(_ctx), _src));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3830,11 +3683,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_video",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_src)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_video", (nodecontext_to_rb_hash(_ctx), _src));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3858,11 +3708,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_iframe",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_src)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_iframe", (nodecontext_to_rb_hash(_ctx), _src));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3886,11 +3733,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_details",
-            (nodecontext_to_rb_hash(_ctx), magnus::Value::from(_open)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_details", (nodecontext_to_rb_hash(_ctx), _open));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3914,11 +3758,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_summary",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_summary", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3939,7 +3780,7 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
             return html_to_markdown_rs::VisitResult::Continue;
         }
         let result: Result<magnus::Value, magnus::Error> =
-            magnus::method::Method::funcall(self.rb_obj, "visit_figure_start", (nodecontext_to_rb_hash(_ctx),));
+            self.rb_obj.funcall("visit_figure_start", (nodecontext_to_rb_hash(_ctx),));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3963,11 +3804,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_figcaption",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_text)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_figcaption", (nodecontext_to_rb_hash(_ctx), _text));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -3991,11 +3829,8 @@ impl html_to_markdown_rs::visitor::HtmlVisitor for RbHtmlVisitorBridge {
         if !responds {
             return html_to_markdown_rs::VisitResult::Continue;
         }
-        let result: Result<magnus::Value, magnus::Error> = magnus::method::Method::funcall(
-            self.rb_obj,
-            "visit_figure_end",
-            (nodecontext_to_rb_hash(_ctx), magnus::RString::new(_output)),
-        );
+        let result: Result<magnus::Value, magnus::Error> =
+            self.rb_obj.funcall("visit_figure_end", (nodecontext_to_rb_hash(_ctx), _output));
         match result {
             Err(_) => html_to_markdown_rs::VisitResult::Continue,
             Ok(val) => {
@@ -4300,7 +4135,7 @@ impl From<ConversionOptionsUpdate> for html_to_markdown_rs::options::ConversionO
             max_image_size: val.max_image_size,
             capture_svg: val.capture_svg,
             infer_dimensions: val.infer_dimensions,
-            max_depth: (val.max_depth).map(Some),
+            max_depth: val.max_depth,
         }
     }
 }
@@ -4346,7 +4181,7 @@ impl From<html_to_markdown_rs::options::ConversionOptionsUpdate> for ConversionO
             max_image_size: val.max_image_size,
             capture_svg: val.capture_svg,
             infer_dimensions: val.infer_dimensions,
-            max_depth: val.max_depth.flatten(),
+            max_depth: val.max_depth,
         }
     }
 }

--- a/packages/ruby/lib/html_to_markdown.rb
+++ b/packages/ruby/lib/html_to_markdown.rb
@@ -28,13 +28,15 @@ module HtmlToMarkdown
   #   - :preserve_tags       - Array of tag names to preserve verbatim
   #   (and more, matching ConversionOptions fields)
   # @return [String] The converted Markdown content.
-  def self.convert(html, options = {})
-    opts = if options.nil? || options.empty?
+  def self.convert(html, options = {}, visitor = nil)
+    opts = if options.is_a?(HtmlToMarkdownRs::ConversionOptions)
+             options
+           elsif options.nil? || options.empty?
              nil
            else
              HtmlToMarkdownRs::ConversionOptions.new(options)
            end
-    result = HtmlToMarkdownRs.convert(html, opts)
+    result = HtmlToMarkdownRs.convert(html, opts, visitor)
     result.content || ''
   end
 end

--- a/packages/ruby/sig/html_to_markdown.rbs
+++ b/packages/ruby/sig/html_to_markdown.rbs
@@ -8,7 +8,7 @@ module HtmlToMarkdownRs
     def content: () -> String?
   end
 
-  def self.convert: (String html, ConversionOptions? options) -> ConversionResult
+  def self.convert: (String html, ConversionOptions? options, untyped? visitor) -> ConversionResult
 end
 
 # Type definitions for HtmlToMarkdown Ruby gem
@@ -145,5 +145,5 @@ module HtmlToMarkdown
   #
   # Example:
   #   result = HtmlToMarkdown.convert(html)
-  def self.convert: (String html, ?conversion_options options) -> String
+  def self.convert: (String html, ?conversion_options options, ?untyped visitor) -> String
 end


### PR DESCRIPTION

  closes #316                                                                               
             
  Both call forms raised `TypeError` in 3.2.4+:                                             
                                                                                            
  ```ruby
  HtmlToMarkdown.convert(html)                                                              
  # TypeError: no implicit conversion of HtmlToMarkdownRs::ConversionResult
  #            into HtmlToMarkdownRs::ConversionResult                                      
                                                                                            
  HtmlToMarkdown.convert(html, extract_metadata: true)                                      
  # TypeError: no implicit conversion of HtmlToMarkdownRs::ConversionOptions into String    
           
 ```                                                 
  root causes                                                                               
   
  bug 1 - options type mismatch (Rust): The FFI was deserializing options from a JSON string (as_deref()...serde_json::from_str), but the Ruby side was passing a ConversionOptions object. Fixed with options.map(Into::into) for direct conversion.                                            
   
  bug 2 - wrong return type (Ruby): HtmlToMarkdown.convert was returning the raw ConversionResult object instead of      
  result.content || '', breaking the documented @return [String] contract and causing TypeErrors in every downstream caller.
                                                                                            
  changes                                                   
                                                                                            
  - ext/html_to_markdown_rb/src/lib.rs — switch to Into conversion for options; replace deprecated magnus::method::Method::funcall with self.rb_obj.funcall across all visitor dispatch; fix erroneous double-Option wrapping on max_depth                                                       
  - lib/html_to_markdown.rb - restore result.content || '' return; add visitor parameter; guard against pre-built ConversionOptions being passed directly                                                                     
  - sig/html_to_markdown.rbs - update signatures for visitor parameter on both HtmlToMarkdownRs.convert and                                          HtmlToMarkdown.convert 