### PR TITLE
docs: add exclude_selectors to all language API references and fix heading hierarchy

### DIFF
--- a/docs/reference/api-c.md
+++ b/docs/reference/api-c.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `bool` | `false` | Capture SVG elements as images. |
 | `infer_dimensions` | `bool` | `true` | Infer image dimensions from data. |
 | `max_depth` | `uintptr_t*` | `NULL` | Maximum DOM traversal depth. `NULL` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `const char**` | `NULL` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```c
 HtmConversionOptionsBuilder htm_keep_inline_images_in(const char** tags);
+```
+
+###### htm_exclude_selectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```c
+HtmConversionOptionsBuilder htm_exclude_selectors(const char** selectors);
 ```
 
 ###### htm_preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```c
 HtmLinkType htm_classify_link(const char* href);
-```
-
-
----
-
-##### HtmMetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `bool` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `bool` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `bool` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `bool` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `bool` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `uintptr_t` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### htm_default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```c
-HtmMetadataConfig htm_default();
-```
-
-###### htm_any_enabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```c
-bool htm_any_enabled();
-```
-
-###### htm_apply_update()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```c
-void htm_apply_update(HtmMetadataConfigUpdate update);
-```
-
-###### htm_from_update()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```c
-HtmMetadataConfig htm_from_update(HtmMetadataConfigUpdate update);
-```
-
-###### htm_from()
-
-**Signature:**
-
-```c
-HtmMetadataConfig htm_from(HtmMetadataConfigUpdate update);
 ```
 
 

--- a/docs/reference/api-csharp.md
+++ b/docs/reference/api-csharp.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `CaptureSvg` | `bool` | `false` | Capture SVG elements as images. |
 | `InferDimensions` | `bool` | `true` | Infer image dimensions from data. |
 | `MaxDepth` | `nuint?` | `null` | Maximum DOM traversal depth. `null` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `ExcludeSelectors` | `List<string>` | `new List<string>()` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```csharp
 public ConversionOptionsBuilder KeepInlineImagesIn(List<string> tags)
+```
+
+###### ExcludeSelectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```csharp
+public ConversionOptionsBuilder ExcludeSelectors(List<string> selectors)
 ```
 
 ###### Preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```csharp
 public LinkType ClassifyLink(string href)
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `ExtractDocument` | `bool` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `ExtractHeaders` | `bool` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `ExtractLinks` | `bool` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `ExtractImages` | `bool` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `ExtractStructuredData` | `bool` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `MaxStructuredDataSize` | `nuint` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### CreateDefault()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```csharp
-public MetadataConfig CreateDefault()
-```
-
-###### AnyEnabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```csharp
-public bool AnyEnabled()
-```
-
-###### ApplyUpdate()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```csharp
-public void ApplyUpdate(MetadataConfigUpdate update)
-```
-
-###### FromUpdate()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```csharp
-public MetadataConfig FromUpdate(MetadataConfigUpdate update)
-```
-
-###### From()
-
-**Signature:**
-
-```csharp
-public MetadataConfig From(MetadataConfigUpdate update)
 ```
 
 

--- a/docs/reference/api-elixir.md
+++ b/docs/reference/api-elixir.md
@@ -86,6 +86,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `boolean()` | `false` | Capture SVG elements as images. |
 | `infer_dimensions` | `boolean()` | `true` | Infer image dimensions from data. |
 | `max_depth` | `integer() | nil` | `nil` | Maximum DOM traversal depth. `nil` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `list(String.t())` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Functions
 
@@ -193,6 +194,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```elixir
 def keep_inline_images_in(tags)
+```
+
+###### exclude_selectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```elixir
+def exclude_selectors(selectors)
 ```
 
 ###### preprocessing()
@@ -829,99 +840,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```elixir
 def classify_link(href)
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `boolean()` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `boolean()` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `boolean()` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `boolean()` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `boolean()` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `integer()` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Functions
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```elixir
-def default()
-```
-
-###### any_enabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```elixir
-def any_enabled()
-```
-
-###### apply_update()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```elixir
-def apply_update(update)
-```
-
-###### from_update()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```elixir
-def from_update(update)
-```
-
-###### from()
-
-**Signature:**
-
-```elixir
-def from(update)
 ```
 
 

--- a/docs/reference/api-go.md
+++ b/docs/reference/api-go.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `CaptureSvg` | `bool` | `false` | Capture SVG elements as images. |
 | `InferDimensions` | `bool` | `true` | Infer image dimensions from data. |
 | `MaxDepth` | `*int` | `nil` | Maximum DOM traversal depth. `nil` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `ExcludeSelectors` | `[]string` | `nil` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```go
 func (o *ConversionOptionsBuilder) KeepInlineImagesIn(tags []string) ConversionOptionsBuilder
+```
+
+###### ExcludeSelectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```go
+func (o *ConversionOptionsBuilder) ExcludeSelectors(selectors []string) ConversionOptionsBuilder
 ```
 
 ###### Preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```go
 func (o *LinkMetadata) ClassifyLink(href string) LinkType
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `ExtractDocument` | `bool` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `ExtractHeaders` | `bool` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `ExtractLinks` | `bool` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `ExtractImages` | `bool` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `ExtractStructuredData` | `bool` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `MaxStructuredDataSize` | `int` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### Default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```go
-func (o *MetadataConfig) Default() MetadataConfig
-```
-
-###### AnyEnabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```go
-func (o *MetadataConfig) AnyEnabled() bool
-```
-
-###### ApplyUpdate()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```go
-func (o *MetadataConfig) ApplyUpdate(update MetadataConfigUpdate)
-```
-
-###### FromUpdate()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```go
-func (o *MetadataConfig) FromUpdate(update MetadataConfigUpdate) MetadataConfig
-```
-
-###### From()
-
-**Signature:**
-
-```go
-func (o *MetadataConfig) From(update MetadataConfigUpdate) MetadataConfig
 ```
 
 

--- a/docs/reference/api-java.md
+++ b/docs/reference/api-java.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `captureSvg` | `boolean` | `false` | Capture SVG elements as images. |
 | `inferDimensions` | `boolean` | `true` | Infer image dimensions from data. |
 | `maxDepth` | `Optional<Long>` | `null` | Maximum DOM traversal depth. `null` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `excludeSelectors` | `List<String>` | `Collections.emptyList()` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```java
 public ConversionOptionsBuilder keepInlineImagesIn(List<String> tags)
+```
+
+###### excludeSelectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```java
+public ConversionOptionsBuilder excludeSelectors(List<String> selectors)
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```java
 public static LinkType classifyLink(String href)
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extractDocument` | `boolean` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extractHeaders` | `boolean` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extractLinks` | `boolean` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extractImages` | `boolean` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extractStructuredData` | `boolean` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `maxStructuredDataSize` | `long` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### defaultOptions()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```java
-public static MetadataConfig defaultOptions()
-```
-
-###### anyEnabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```java
-public boolean anyEnabled()
-```
-
-###### applyUpdate()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```java
-public void applyUpdate(MetadataConfigUpdate update)
-```
-
-###### fromUpdate()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```java
-public static MetadataConfig fromUpdate(MetadataConfigUpdate update)
-```
-
-###### from()
-
-**Signature:**
-
-```java
-public static MetadataConfig from(MetadataConfigUpdate update)
 ```
 
 

--- a/docs/reference/api-php.md
+++ b/docs/reference/api-php.md
@@ -85,6 +85,7 @@ Use `ConversionOptions::builder()` to construct, or `the default constructor` fo
 | `captureSvg` | `bool` | `false` | Capture SVG elements as images. |
 | `inferDimensions` | `bool` | `true` | Infer image dimensions from data. |
 | `maxDepth` | `?int` | `null` | Maximum DOM traversal depth. `null` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `excludeSelectors` | `array<string>` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```php
 public function keepInlineImagesIn(array<string> $tags): ConversionOptionsBuilder
+```
+
+###### excludeSelectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```php
+public function excludeSelectors(array<string> $selectors): ConversionOptionsBuilder
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```php
 public static function classifyLink(string $href): LinkType
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extractDocument` | `bool` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extractHeaders` | `bool` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extractLinks` | `bool` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extractImages` | `bool` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extractStructuredData` | `bool` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `maxStructuredDataSize` | `int` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```php
-public static function default(): MetadataConfig
-```
-
-###### anyEnabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```php
-public function anyEnabled(): bool
-```
-
-###### applyUpdate()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```php
-public function applyUpdate(MetadataConfigUpdate $update): void
-```
-
-###### fromUpdate()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```php
-public static function fromUpdate(MetadataConfigUpdate $update): MetadataConfig
-```
-
-###### from()
-
-**Signature:**
-
-```php
-public static function from(MetadataConfigUpdate $update): MetadataConfig
 ```
 
 

--- a/docs/reference/api-python.md
+++ b/docs/reference/api-python.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `bool` | `False` | Capture SVG elements as images. |
 | `infer_dimensions` | `bool` | `True` | Infer image dimensions from data. |
 | `max_depth` | `int | None` | `None` | Maximum DOM traversal depth. `None` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `list[str]` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -196,6 +197,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```python
 def keep_inline_images_in(self, tags: list[str]) -> ConversionOptionsBuilder
+```
+
+###### exclude_selectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```python
+def exclude_selectors(self, selectors: list[str]) -> ConversionOptionsBuilder
 ```
 
 ###### preprocessing()
@@ -833,102 +844,6 @@ Appropriate `LinkType` based on protocol and content.
 ```python
 @staticmethod
 def classify_link(href: str) -> LinkType
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `bool` | `True` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `bool` | `True` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `bool` | `True` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `bool` | `True` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `bool` | `True` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `int` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```python
-@staticmethod
-def default() -> MetadataConfig
-```
-
-###### any_enabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `True` if at least one extraction category is enabled, `False` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`True` if any of the extraction flags are enabled, `False` if all are disabled.
-
-**Signature:**
-
-```python
-def any_enabled(self) -> bool
-```
-
-###### apply_update()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```python
-def apply_update(self, update: MetadataConfigUpdate) -> None
-```
-
-###### from_update()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```python
-@staticmethod
-def from_update(update: MetadataConfigUpdate) -> MetadataConfig
-```
-
-###### from()
-
-**Signature:**
-
-```python
-@staticmethod
-def from(update: MetadataConfigUpdate) -> MetadataConfig
 ```
 
 

--- a/docs/reference/api-r.md
+++ b/docs/reference/api-r.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `logical` | `false` | Capture SVG elements as images. |
 | `infer_dimensions` | `logical` | `true` | Infer image dimensions from data. |
 | `max_depth` | `integer or NULL` | `NULL` | Maximum DOM traversal depth. `NULL` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `list` | `list()` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```r
 keep_inline_images_in(tags)
+```
+
+###### exclude_selectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```r
+exclude_selectors(selectors)
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```r
 classify_link(href)
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `logical` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `logical` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `logical` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `logical` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `logical` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `integer` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```r
-default()
-```
-
-###### any_enabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```r
-any_enabled()
-```
-
-###### apply_update()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```r
-apply_update(update)
-```
-
-###### from_update()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```r
-from_update(update)
-```
-
-###### from()
-
-**Signature:**
-
-```r
-from(update)
 ```
 
 

--- a/docs/reference/api-ruby.md
+++ b/docs/reference/api-ruby.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `Boolean` | `false` | Capture SVG elements as images. |
 | `infer_dimensions` | `Boolean` | `true` | Infer image dimensions from data. |
 | `max_depth` | `Integer?` | `nil` | Maximum DOM traversal depth. `nil` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `Array<String>` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```ruby
 def keep_inline_images_in(tags)
+```
+
+###### exclude_selectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```ruby
+def exclude_selectors(selectors)
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```ruby
 def self.classify_link(href)
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `Boolean` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `Boolean` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `Boolean` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `Boolean` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `Boolean` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `Integer` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```ruby
-def self.default()
-```
-
-###### any_enabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```ruby
-def any_enabled()
-```
-
-###### apply_update()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```ruby
-def apply_update(update)
-```
-
-###### from_update()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```ruby
-def self.from_update(update)
-```
-
-###### from()
-
-**Signature:**
-
-```ruby
-def self.from(update)
 ```
 
 

--- a/docs/reference/api-rust.md
+++ b/docs/reference/api-rust.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `bool` | `false` | Capture SVG elements as images. |
 | `infer_dimensions` | `bool` | `true` | Infer image dimensions from data. |
 | `max_depth` | `Option<usize>` | `None` | Maximum DOM traversal depth. `None` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `Vec<String>` | `vec![]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```rust
 pub fn keep_inline_images_in(&self, tags: Vec<String>) -> ConversionOptionsBuilder
+```
+
+###### exclude_selectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```rust
+pub fn exclude_selectors(&self, selectors: Vec<String>) -> ConversionOptionsBuilder
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```rust
 pub fn classify_link(href: &str) -> LinkType
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `bool` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `bool` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `bool` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `bool` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `bool` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `usize` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```rust
-pub fn default() -> MetadataConfig
-```
-
-###### any_enabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```rust
-pub fn any_enabled(&self) -> bool
-```
-
-###### apply_update()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```rust
-pub fn apply_update(&self, update: MetadataConfigUpdate)
-```
-
-###### from_update()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```rust
-pub fn from_update(update: MetadataConfigUpdate) -> MetadataConfig
-```
-
-###### from()
-
-**Signature:**
-
-```rust
-pub fn from(update: MetadataConfigUpdate) -> MetadataConfig
 ```
 
 

--- a/docs/reference/api-typescript.md
+++ b/docs/reference/api-typescript.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `captureSvg` | `boolean` | `false` | Capture SVG elements as images. |
 | `inferDimensions` | `boolean` | `true` | Infer image dimensions from data. |
 | `maxDepth` | `number | null` | `null` | Maximum DOM traversal depth. `null` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `excludeSelectors` | `Array<string>` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```typescript
 keepInlineImagesIn(tags: Array<string>): ConversionOptionsBuilder
+```
+
+###### excludeSelectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```typescript
+excludeSelectors(selectors: Array<string>): ConversionOptionsBuilder
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```typescript
 static classifyLink(href: string): LinkType
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extractDocument` | `boolean` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extractHeaders` | `boolean` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extractLinks` | `boolean` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extractImages` | `boolean` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extractStructuredData` | `boolean` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `maxStructuredDataSize` | `number` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```typescript
-static default(): MetadataConfig
-```
-
-###### anyEnabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```typescript
-anyEnabled(): boolean
-```
-
-###### applyUpdate()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```typescript
-applyUpdate(update: MetadataConfigUpdate): void
-```
-
-###### fromUpdate()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```typescript
-static fromUpdate(update: MetadataConfigUpdate): MetadataConfig
-```
-
-###### from()
-
-**Signature:**
-
-```typescript
-static from(update: MetadataConfigUpdate): MetadataConfig
 ```
 
 

--- a/docs/reference/api-wasm.md
+++ b/docs/reference/api-wasm.md
@@ -85,6 +85,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `captureSvg` | `boolean` | `false` | Capture SVG elements as images. |
 | `inferDimensions` | `boolean` | `true` | Infer image dimensions from data. |
 | `maxDepth` | `number | null` | `null` | Maximum DOM traversal depth. `null` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `excludeSelectors` | `Array<string>` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ##### Methods
 
@@ -192,6 +193,16 @@ Set the list of HTML tag names whose `<img>` children are kept inline.
 
 ```typescript
 keepInlineImagesIn(tags: Array<string>): ConversionOptionsBuilder
+```
+
+###### excludeSelectors()
+
+Set the list of CSS selectors for elements to exclude entirely from output.
+
+**Signature:**
+
+```typescript
+excludeSelectors(selectors: Array<string>): ConversionOptionsBuilder
 ```
 
 ###### preprocessing()
@@ -828,99 +839,6 @@ Appropriate `LinkType` based on protocol and content.
 
 ```typescript
 static classifyLink(href: string): LinkType
-```
-
-
----
-
-##### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extractDocument` | `boolean` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extractHeaders` | `boolean` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extractLinks` | `boolean` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extractImages` | `boolean` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extractStructuredData` | `boolean` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `maxStructuredDataSize` | `number` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
-###### Methods
-
-###### default()
-
-Create default metadata configuration.
-
-Defaults to extracting all metadata types with 1MB limit on structured data.
-
-**Signature:**
-
-```typescript
-static default(): MetadataConfig
-```
-
-###### anyEnabled()
-
-Check if any metadata extraction is enabled.
-
-Returns `true` if at least one extraction category is enabled, `false` if all are disabled.
-This is useful for early exit optimization when the application doesn't need metadata.
-
-**Returns:**
-
-`true` if any of the extraction flags are enabled, `false` if all are disabled.
-
-**Signature:**
-
-```typescript
-anyEnabled(): boolean
-```
-
-###### applyUpdate()
-
-Apply a partial update to this metadata configuration.
-
-Any specified fields in the update (Some values) will override the current values.
-Unspecified fields (None) are left unchanged. This allows selective modification
-of configuration without affecting unrelated settings.
-
-**Signature:**
-
-```typescript
-applyUpdate(update: MetadataConfigUpdate): void
-```
-
-###### fromUpdate()
-
-Create new metadata configuration from a partial update.
-
-Creates a new `MetadataConfig` struct with defaults, then applies the update.
-Fields not specified in the update (None) keep their default values.
-This is a convenience method for constructing a configuration from a partial specification
-without needing to explicitly call `.default()` first.
-
-**Returns:**
-
-New `MetadataConfig` with specified updates applied to defaults
-
-**Signature:**
-
-```typescript
-static fromUpdate(update: MetadataConfigUpdate): MetadataConfig
-```
-
-###### from()
-
-**Signature:**
-
-```typescript
-static from(update: MetadataConfigUpdate): MetadataConfig
 ```
 
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -6,26 +6,6 @@ title: "Configuration Reference"
 
 This page documents all configuration types and their defaults across all languages.
 
-### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `bool` | `True` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `bool` | `True` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `bool` | `True` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `bool` | `True` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `bool` | `True` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `int` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
----
-
 ### DocumentMetadata
 
 Document-level metadata extracted from `<head>` and top-level elements.
@@ -113,6 +93,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `bool` | `False` | Capture SVG elements as images. |
 | `infer_dimensions` | `bool` | `True` | Infer image dimensions from data. |
 | `max_depth` | `int | None` | `None` | Maximum DOM traversal depth. `None` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `list[str]` | `[]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ---
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -77,6 +77,7 @@ Use `ConversionOptions.builder()` to construct, or `the default constructor` for
 | `capture_svg` | `bool` | `false` | Capture SVG elements as images. |
 | `infer_dimensions` | `bool` | `true` | Infer image dimensions from data. |
 | `max_depth` | `Option<usize>` | `None` | Maximum DOM traversal depth. `None` means unlimited. When set, subtrees beyond this depth are silently truncated. |
+| `exclude_selectors` | `Vec<String>` | `vec![]` | CSS selectors for elements to exclude entirely (element + all content). Unlike `strip_tags` (which removes the tag wrapper but keeps children), excluded elements and all their descendants are dropped from the output. Supports any CSS selector that `tl` supports: tag names, `.class`, `#id`, `[attribute]`, etc. Invalid selectors are silently skipped at conversion time. Example: `vec![".cookie-banner".into(), "#ad-container".into(), "[role='complementary']".into()]` |
 
 ---
 
@@ -106,26 +107,6 @@ A structured table grid with cell-level data including spans.
 ---
 
 ### Metadata Types
-
-#### MetadataConfig
-
-Configuration for metadata extraction granularity.
-
-Controls which metadata types are extracted and size limits for safety.
-Enables selective extraction of different metadata categories from HTML documents,
-allowing fine-grained control over which types of information to collect during
-the HTML-to-Markdown conversion process.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `extract_document` | `bool` | `true` | Extract document-level metadata (title, description, author, etc.). When enabled, collects metadata from `<head>` section including: - `<title>` element content - `<meta name="description">` and other standard meta tags - Open Graph (og:*) properties for social media optimization - Twitter Card (twitter:*) properties - Language and text direction attributes - Canonical URL and base href references |
-| `extract_headers` | `bool` | `true` | Extract h1-h6 header elements and their hierarchy. When enabled, collects all heading elements with: - Header level (1-6) - Text content (normalized) - HTML id attribute if present - Document tree depth for hierarchy tracking - Byte offset in original HTML for positioning |
-| `extract_links` | `bool` | `true` | Extract anchor (a) elements as links with type classification. When enabled, collects all hyperlinks with: - href attribute value - Link text content - Title attribute (tooltip text) - Automatic link type classification (anchor, internal, external, email, phone, other) - Rel attribute values - Additional custom attributes |
-| `extract_images` | `bool` | `true` | Extract image elements and data URIs. When enabled, collects all image elements with: - Source URL or data URI - Alt text for accessibility - Title attribute - Dimensions (width, height) if available - Automatic image type classification (data URI, external, relative, inline SVG) - Additional custom attributes |
-| `extract_structured_data` | `bool` | `true` | Extract structured data (JSON-LD, Microdata, RDFa). When enabled, collects machine-readable structured data including: - JSON-LD script blocks with schema detection - Microdata attributes (itemscope, itemtype, itemprop) - RDFa markup - Extracted schema type if detectable |
-| `max_structured_data_size` | `usize` | — | Maximum total size of structured data to collect (bytes). Prevents memory exhaustion attacks on malformed or adversarial documents containing excessively large structured data blocks. When the accumulated size of structured data exceeds this limit, further collection stops. Default: `1_000_000` bytes (1 MB) |
-
----
 
 #### DocumentMetadata
 


### PR DESCRIPTION
## Situation

The `exclude_selectors` option was added to the core library (feat: add exclude_selectors for CSS selector-based element exclusion) but the API reference documentation for all language bindings did not yet reflect this new option.

## Task

Update all 12 language API reference docs to document the `exclude_selectors`/`ExcludeSelectors` field and builder method, and fix any heading hierarchy issues surfaced during the update.

## Action

- Added `exclude_selectors` field to the `ConversionOptions` table in all language API references: C, C#, Elixir, Go, Java, PHP, Python, R, Ruby, Rust, TypeScript, Wasm
- Added `ExcludeSelectors()` / `exclude_selectors()` builder method documentation for each binding
- Added `exclude_selectors` field to `docs/reference/configuration.md`
- Removed stale `MetadataConfig` section from `docs/reference/configuration.md`
- Fixed heading hierarchy violations (MD025 multiple top-level headings, MD001 heading level jumps, MD032 list blank lines) across multiple docs

## Result

All language API reference pages are now consistent with the current library feature set. The `exclude_selectors` option is fully documented across all bindings, and markdown linting passes cleanly.

## Acceptance Criteria

- [x] `exclude_selectors` documented in all 12 language API references
- [x] Builder method documented for each binding
- [x] `configuration.md` updated with new field and stale section removed
- [x] All markdown lint checks pass