### PR TITLE
add Dart/Flutter FFI bindings as git submodule

### DIFF
--- a/.github/workflows/build-dart-ffi.yml
+++ b/.github/workflows/build-dart-ffi.yml
@@ -1,0 +1,52 @@
+name: Build Dart FFI Library
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+            ext: dylib
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            ext: dylib
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            ext: so
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --release -p html-to-markdown-ffi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libhtml_to_markdown_ffi-${{ matrix.target }}
+          path: target/release/libhtml_to_markdown_ffi.${{ matrix.ext }}
+
+  attach:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: libhtml_to_markdown_ffi-*
+          merge-multiple: true
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for f in libhtml_to_markdown_ffi-*; do
+            gh release upload "${{ github.event.release.tag_name }}" "$f"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,7 @@ vendor/
 AGENTS.md
 CLAUDE.md
 # END ai-rulez
+MANIFESTO.md
+specs
+.specify
+.opencode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "homebrew-tap"]
 	path = homebrew-tap
 	url = https://github.com/Goldziher/homebrew-tap.git
+[submodule "packages/dart"]
+	path = packages/dart
+	url = git@github.com:arrrrny/html_to_markdown_ffi.git


### PR DESCRIPTION
## Summary

Adds a Dart/Flutter binding package for html-to-markdown as a git submodule at `packages/dart/`.

The package (`html_to_markdown_ffi`) wraps the C FFI layer using `dart:ffi` and provides:
- `convert()` function with full option support (43 fields)
- Metadata extraction (title, description, keywords, OpenGraph, JSON-LD)
- Visitor pattern (38 element-level callbacks)
- 76 tests across 9 categories (smoke, conversion, options, metadata, result, visitor, edge cases, real-world, structure)
- Zero analyze errors
- Published on pub.dev