### PR TITLE
fix(ci): unblock Test: PHP and Test: Node jobs

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -496,6 +496,7 @@ jobs:
         uses: shivammathur/setup-php@2.37.1 # 2
         with:
           php-version: "8.4"
+          extensions: ctype, dom, json, libxml, mbstring, tokenizer, xml, xmlwriter
           tools: composer:2.9.8
           coverage: none
 
@@ -866,6 +867,7 @@ jobs:
         uses: shivammathur/setup-php@2.37.1 # 2
         with:
           php-version: "8.4"
+          extensions: ctype, dom, json, libxml, mbstring, tokenizer, xml, xmlwriter
           tools: composer:2.9.8
           coverage: none
 

--- a/alef.toml
+++ b/alef.toml
@@ -1,5 +1,5 @@
 [workspace]
-alef_version = "0.16.45"
+alef_version = "0.16.69"
 languages = [
   "python",
   "node",
@@ -305,8 +305,8 @@ e2e = "cd e2e/python && uv run pytest tests/ -q"
 
 [crates.test.node]
 precondition = "command -v pnpm >/dev/null 2>&1"
-before = "cd crates/html-to-markdown-node && napi build --platform --release && cd ../../packages/typescript && pnpm install --silent && pnpm run build"
-e2e = "cd e2e/node && pnpm install --silent && pnpm exec vitest run"
+before = "cd crates/html-to-markdown-node && napi build --platform --release && cd ../../packages/typescript && pnpm install && pnpm run build"
+e2e = "cd e2e/node && pnpm install && pnpm exec vitest run"
 
 [crates.test.go]
 precondition = "command -v go >/dev/null 2>&1"


### PR DESCRIPTION
## Summary

- Add `extensions: ctype, dom, json, libxml, mbstring, tokenizer, xml, xmlwriter` to both `setup-php` invocations in `ci-e2e.yaml`. The default install set is missing the extensions PHPUnit 13.x requires, so `Test: PHP` fails any time the gated job actually runs (e.g. dependabot PRs touching `composer.lock`).
- Drop `--silent` from the `[crates.test.node]` `before` and `e2e` hooks in `alef.toml` so pnpm build errors surface in CI instead of being swallowed. `alef_version` pin bumped to v0.16.69 by `alef generate`.

Unblocks dependabot PRs #365, #366, #367.

## Test plan

- [ ] CI green on this PR (PHP + Node test jobs run on the workflow path change)
- [ ] After merge: rebase #365, #366, #367 and confirm green