### PR TITLE
fix(docs): unify Discord invite to canonical xt9WY3GnKR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,7 +385,7 @@ Verify all distributions are published:
 
 - **Issues**: [GitHub Issues](https://github.com/kreuzberg-dev/html-to-markdown/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/kreuzberg-dev/html-to-markdown/discussions)
-- **Discord**: [Kreuzberg Community](https://discord.gg/pXxagNK2zN)
+- **Discord**: [Kreuzberg Community](https://discord.gg/xt9WY3GnKR)
 
 ### License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,7 +43,7 @@ New pages go in `docs/`, must be added to `nav:` in `mkdocs.yaml`, and should fo
 ## Getting help
 
 - **Have Any Questions** — [Join the GitHub Discussions](https://github.com/kreuzberg-dev/html-to-markdown/discussions)
-- **Join Our community** — [Discord](https://discord.gg/pXxagNK2zN)
+- **Join Our community** — [Discord](https://discord.gg/xt9WY3GnKR)
 - **Report a Bugs** — [GitHub Issues](https://github.com/kreuzberg-dev/html-to-markdown/issues)
 
 --8<-- "snippets/feedback.md"


### PR DESCRIPTION
Two files referenced the stale pXxagNK2zN invite instead of the canonical xt9WY3GnKR used across all other repos.

Changes:
- CONTRIBUTING.md line 388
- docs/contributing.md line 46