### PR TITLE
docs: update canonical product counts in ecosystem block (92 formats, 16 languages)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+html-to-markdown is committed to a welcoming, respectful community for everyone regardless of
+background or experience level.
+
+## Expected Behaviour
+
+- Be respectful and constructive in all interactions.
+- Accept feedback graciously; give it thoughtfully.
+- Focus discussions on technical substance.
+- Assume good faith until evidence suggests otherwise.
+
+## Unacceptable Behaviour
+
+Personal attacks, sustained disruption, and discriminatory language are not tolerated.
+
+## Enforcement
+
+Report issues to **<conduct@kreuzberg.dev>**. All reports are reviewed confidentially.
+Maintainers may warn, temporarily restrict, or permanently remove contributors whose
+behaviour harms the community.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — issues, pull requests, discussions,
+Discord, and any other venue where contributors represent the project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security reports.**
+
+Preferred channel: open a private advisory at
+<https://github.com/kreuzberg-dev/html-to-markdown/security/advisories/new>.
+
+Alternative: email **<security@kreuzberg.dev>**.
+
+Please include a description of the issue, steps to reproduce, affected versions, and your
+preferred credit (or none). We acknowledge reports within **2 business days** and aim to
+publish a fix within **14 days** for critical issues and **30 days** for others.
+
+## Supported Versions
+
+Security fixes target the latest release on `main`. Older versions are not back-ported.
+
+## Scope
+
+In scope: the html-to-markdown library and its bindings.
+Out of scope: third-party dependencies (report upstream and notify us).


### PR DESCRIPTION
Updates two ecosystem block references:
- kreuzberg format count: `91+` → `92`
- liter-llm binding count: `14 languages` → `16 languages`