### PR TITLE
feat(docs): add Dart/Flutter unofficial binding to README

### DIFF
--- a/crates/html-to-markdown/README.md
+++ b/crates/html-to-markdown/README.md
@@ -267,6 +267,7 @@ This is the core Rust library. For other languages:
 
 - **JavaScript/TypeScript**: [html-to-markdown-node](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-node) (NAPI-RS) or [html-to-markdown-wasm](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-wasm) (WebAssembly)
 - **Python**: [html-to-markdown](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-py) (PyO3)
+- **Dart/Flutter**: [h2m](https://pub.dev/packages/h2m) (official Dart binding) or [html_to_markdown_rust](https://pub.dev/packages/html_to_markdown_rust) (unofficial FFI wrapper via Hooks)
 - **PHP**: [html-to-markdown](https://github.com/xberg-io/html-to-markdown/tree/main/packages/php) (PIE + Composer helpers)
 - **Ruby**: [html-to-markdown](https://github.com/xberg-io/html-to-markdown/tree/main/packages/ruby) (Magnus + rb-sys)
 - **CLI**: [html-to-markdown-cli](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-cli)

--- a/readme_templates/rust.md
+++ b/readme_templates/rust.md
@@ -267,6 +267,7 @@ This is the core Rust library. For other languages:
 
 - **JavaScript/TypeScript**: [html-to-markdown-node](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-node) (NAPI-RS) or [html-to-markdown-wasm](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-wasm) (WebAssembly)
 - **Python**: [html-to-markdown](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-py) (PyO3)
+- **Dart/Flutter**: [h2m](https://pub.dev/packages/h2m) (official Dart binding) or [html_to_markdown_rust](https://pub.dev/packages/html_to_markdown_rust) (unofficial FFI wrapper via Hooks)
 - **PHP**: [html-to-markdown](https://github.com/xberg-io/html-to-markdown/tree/main/packages/php) (PIE + Composer helpers)
 - **Ruby**: [html-to-markdown](https://github.com/xberg-io/html-to-markdown/tree/main/packages/ruby) (Magnus + rb-sys)
 - **CLI**: [html-to-markdown-cli](https://github.com/xberg-io/html-to-markdown/tree/main/crates/html-to-markdown-cli)


### PR DESCRIPTION
## Related

N/A

## Description

I would like to actively maintain this solution for the Dart/Flutter ecosystem.

This PR adds the unofficial Dart/Flutter package [`html_to_markdown_rust`](https://pub.dev/packages/html_to_markdown_rust) to the Rust crate README's "Other Language Bindings" section.

The existing official Dart binding [`h2m`](https://pub.dev/packages/h2m) remains listed as the official package, while `html_to_markdown_rust` is described as an unofficial FFI wrapper around `html-to-markdown-rs`.

Updated both:

- `crates/html-to-markdown/README.md`
- `readme_templates/rust.md`

Validation:

- Ran `git diff --check`
- No tests added; documentation-only change

## Checklist

- [ ] CI passing
- [x] Tests added where applicable
