### PR TITLE
fix: emit depth-limit warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Emit the existing `DepthLimitExceeded` processing warning exactly once when DOM traversal skips
+  nodes at the effective depth limit, including explicit limits routed through Tier-2.
+
 ## [3.8.3] - 2026-07-09
 
 ### Fixed

--- a/crates/html-to-markdown-cli/src/args.rs
+++ b/crates/html-to-markdown-cli/src/args.rs
@@ -377,8 +377,8 @@ pub struct Cli {
 
     /// Maximum DOM traversal depth
     ///
-    /// Silently truncate subtrees beyond this nesting depth. Useful for
-    /// pathologically deep documents. Omit for unlimited depth (default).
+    /// Truncate subtrees beyond this nesting depth. Records a processing warning;
+    /// use --show-warnings to print it. Omission uses the native-stack safety limit.
     #[arg(long, value_name = "N")]
     #[arg(help_heading = "Element Handling")]
     pub max_depth: Option<usize>,

--- a/crates/html-to-markdown/src/convert_api.rs
+++ b/crates/html-to-markdown/src/convert_api.rs
@@ -212,7 +212,7 @@ fn convert_inner(html: &str, options: ConversionOptions) -> Result<ConversionRes
     // ~keep Run the conversion pipeline.
     // ~keep Pass structure_collector by value — convert_html_impl will consume it via Rc::try_unwrap
     // ~keep to return the finished DocumentStructure. We must not hold a second Rc reference.
-    let (markdown, document, tables) = {
+    let (markdown, document, tables, depth_warning) = {
         #[cfg(all(feature = "metadata", feature = "inline-images"))]
         {
             crate::converter::convert_html_impl(
@@ -286,7 +286,7 @@ fn convert_inner(html: &str, options: ConversionOptions) -> Result<ConversionRes
     };
 
     #[cfg(feature = "inline-images")]
-    let warnings: Vec<crate::types::ProcessingWarning> = image_warnings
+    let mut warnings: Vec<crate::types::ProcessingWarning> = image_warnings
         .into_iter()
         .map(|w| crate::types::ProcessingWarning {
             kind: crate::types::WarningKind::ImageExtractionFailed,
@@ -294,7 +294,10 @@ fn convert_inner(html: &str, options: ConversionOptions) -> Result<ConversionRes
         })
         .collect();
     #[cfg(not(feature = "inline-images"))]
-    let warnings: Vec<crate::types::ProcessingWarning> = Vec::new();
+    let mut warnings: Vec<crate::types::ProcessingWarning> = Vec::new();
+    if let Some(warning) = depth_warning {
+        warnings.push(warning);
+    }
 
     let _ = wants_metadata;
     let _ = wants_images;

--- a/crates/html-to-markdown/src/converter/context.rs
+++ b/crates/html-to-markdown/src/converter/context.rs
@@ -4,6 +4,7 @@
 //! HTML to Markdown. It tracks nesting levels, element types, and feature-specific collectors
 //! that are passed through the conversion pipeline.
 
+use std::cell::Cell;
 #[cfg(any(feature = "inline-images", feature = "visitor"))]
 use std::cell::RefCell;
 #[cfg(feature = "metadata")]
@@ -84,6 +85,8 @@ pub struct Context {
     pub(crate) keep_inline_images_in: Rc<HashSet<String>>,
     /// Node IDs matching `exclude_selectors` — these nodes and all descendants are dropped.
     pub(crate) excluded_node_ids: Rc<HashSet<u32>>,
+    /// Shared flag set when the guarded DOM walk reaches its effective depth limit.
+    pub(crate) depth_limit_reached: Rc<Cell<bool>>,
     #[cfg(feature = "inline-images")]
     /// Shared collector for inline images when enabled.
     pub(crate) inline_collector: Option<InlineCollectorHandle>,
@@ -206,6 +209,7 @@ impl Context {
             preserve_tags: Rc::new(options.preserve_tags.iter().cloned().collect()),
             keep_inline_images_in: Rc::new(options.keep_inline_images_in.iter().cloned().collect()),
             excluded_node_ids: Rc::new(HashSet::new()),
+            depth_limit_reached: Rc::new(Cell::new(false)),
             #[cfg(feature = "inline-images")]
             inline_collector,
             #[cfg(feature = "metadata")]

--- a/crates/html-to-markdown/src/converter/main.rs
+++ b/crates/html-to-markdown/src/converter/main.rs
@@ -36,10 +36,17 @@ use crate::options::ConversionOptions;
 use crate::converter::context::{Context, InlineCollectorHandle};
 use crate::types::structure_collector::StructureCollectorHandle;
 
+type ConversionOutput = (
+    String,
+    Option<crate::types::DocumentStructure>,
+    Vec<crate::types::TableData>,
+    Option<crate::types::ProcessingWarning>,
+);
+
 /// Internal implementation of HTML to Markdown conversion.
 ///
-/// Returns `(markdown, Option<DocumentStructure>)`.  The structure is populated when
-/// `options.include_document_structure == true` and a `structure_collector` handle is provided.
+/// Returns the converted content, optional document structure, extracted tables, and an
+/// optional depth-limit warning.
 #[cfg_attr(
     any(not(feature = "inline-images"), not(feature = "metadata"), not(feature = "visitor")),
     allow(unused_variables)
@@ -54,11 +61,7 @@ pub fn convert_html_impl(
     #[cfg(feature = "visitor")] visitor: Option<crate::visitor::VisitorHandle>,
     #[cfg(not(feature = "visitor"))] _visitor: Option<()>,
     structure_collector: Option<StructureCollectorHandle>,
-) -> Result<(
-    String,
-    Option<crate::types::DocumentStructure>,
-    Vec<crate::types::TableData>,
-)> {
+) -> Result<ConversionOutput> {
     let stripped = strip_script_and_style_tags(html);
     let stripped = strip_hidden_elements(&stripped);
     // ~keep Normalise bogus HTML comment endings (`--->`, `---->`, …) that cause the
@@ -267,6 +270,12 @@ pub fn convert_html_impl(
         return Err(crate::error::ConversionError::Visitor(err.clone()));
     }
 
+    let max_depth = effective_max_depth(options);
+    let depth_warning = ctx.depth_limit_reached.get().then(|| crate::types::ProcessingWarning {
+        kind: crate::types::WarningKind::DepthLimitExceeded,
+        message: format!("DOM traversal reached the effective depth limit of {max_depth}; deeper nodes were skipped."),
+    });
+
     // ~keep Drop ctx before unwrapping the structure collector Rc — ctx holds a cloned Rc
     // ~keep reference to the same collector, and Rc::try_unwrap requires exactly one reference.
     drop(ctx);
@@ -291,7 +300,7 @@ pub fn convert_html_impl(
         output
     };
     let (document, tables) = finish_structure_collector(structure_collector);
-    Ok((output, document, tables))
+    Ok((output, document, tables, depth_warning))
 }
 
 /// Consume the structure collector and return the [`DocumentStructure`] and extracted
@@ -324,6 +333,7 @@ pub fn walk_node(
     let Some(node) = node_handle.get(parser) else { return };
 
     if depth >= effective_max_depth(options) {
+        ctx.depth_limit_reached.set(true);
         return;
     }
 

--- a/crates/html-to-markdown/src/converter/tier1/router.rs
+++ b/crates/html-to-markdown/src/converter/tier1/router.rs
@@ -24,6 +24,8 @@ pub enum RouterDecision {
 /// - `options.wrap` — wrapping logic lives in the Tier-2 path (for now)
 /// - `options.convert_as_inline` — inline-conversion mode not yet in Tier-1
 /// - `options.hocr_spatial_tables` — hOCR spatial reconstruction is Tier-2 only
+/// - `options.max_depth.is_some()` — Tier-1 does not implement explicit depth
+///   truncation or warnings
 /// - `options.preprocessing.preset != PreprocessingPreset::Standard`
 ///   — non-standard preprocessing has Tier-2-specific semantics
 /// - `!options.strip_tags.is_empty()` — tag stripping requires DOM awareness
@@ -88,6 +90,7 @@ pub fn classify(report: &PrescanReport, options: &ConversionOptions) -> RouterDe
         || report.had_unescaped_lt
         || options.wrap
         || options.convert_as_inline
+        || options.max_depth.is_some()
         || options.preprocessing.preset != PreprocessingPreset::Standard
         || !options.strip_tags.is_empty()
         || !options.preserve_tags.is_empty()

--- a/crates/html-to-markdown/src/mcp/params.rs
+++ b/crates/html-to-markdown/src/mcp/params.rs
@@ -108,7 +108,7 @@ pub struct ConvertConfig {
     pub capture_svg: Option<bool>,
     /// Infer image dimensions from data. Default `true`.
     pub infer_dimensions: Option<bool>,
-    /// Maximum DOM traversal depth; omit for unlimited.
+    /// Maximum DOM traversal depth; omission uses the native-stack safety limit.
     pub max_depth: Option<u64>,
     /// CSS selectors for elements to exclude entirely (element + descendants).
     pub exclude_selectors: Option<Vec<String>>,

--- a/crates/html-to-markdown/tests/test_max_depth.rs
+++ b/crates/html-to-markdown/tests/test_max_depth.rs
@@ -3,13 +3,21 @@
 
 //! Tests for the `max_depth` recursion-safety option.
 
-use html_to_markdown_rs::ConversionOptions;
+use html_to_markdown_rs::options::{OutputFormat, TierStrategy};
+use html_to_markdown_rs::{ConversionOptions, ConversionResult, WarningKind};
 
-fn convert_with_options(html: &str, options: ConversionOptions) -> String {
-    html_to_markdown_rs::convert(html, Some(options))
-        .expect("conversion should not fail")
-        .content
-        .unwrap_or_default()
+fn convert_with_options(html: &str, options: ConversionOptions) -> ConversionResult {
+    html_to_markdown_rs::convert(html, Some(options)).expect("conversion should not fail")
+}
+
+fn assert_depth_warning(result: &ConversionResult, max_depth: usize) {
+    assert_eq!(result.warnings.len(), 1, "expected exactly one depth warning");
+    let warning = &result.warnings[0];
+    assert_eq!(warning.kind, WarningKind::DepthLimitExceeded);
+    assert_eq!(
+        warning.message,
+        format!("DOM traversal reached the effective depth limit of {max_depth}; deeper nodes were skipped.")
+    );
 }
 
 /// With the default `max_depth: None`, ordinary nesting below the native stack
@@ -28,14 +36,15 @@ fn test_max_depth_none_converts_reasonably_nested_content() {
     };
 
     let result = convert_with_options(&html, options);
+    let content = result.content.as_deref().unwrap_or_default();
     assert!(
-        result.contains("deep"),
-        "Deeply nested text should be present when max_depth is None. Got:\n{result}"
+        content.contains("deep"),
+        "Deeply nested text should be present when max_depth is None. Got:\n{content}"
     );
+    assert!(result.warnings.is_empty());
 }
 
-/// With `max_depth: Some(2)`, block elements at depth 2 are not visited, so
-/// their text content is excluded from the output.
+/// Content at the configured limit is truncated and reported.
 #[test]
 fn test_max_depth_truncates_at_limit() {
     let html = "<div><p>shallow</p><div><p>deep</p></div></div>";
@@ -47,17 +56,36 @@ fn test_max_depth_truncates_at_limit() {
     };
 
     let result = convert_with_options(html, options);
+    let content = result.content.as_deref().unwrap_or_default();
     assert!(
-        result.contains("shallow"),
-        "Content at depth < max_depth should be present. Got:\n{result}"
+        content.contains("shallow"),
+        "Content at depth < max_depth should be present. Got:\n{content}"
     );
     assert!(
-        !result.contains("deep"),
-        "Content at depth >= max_depth should be absent. Got:\n{result}"
+        !content.contains("deep"),
+        "Content at depth >= max_depth should be absent. Got:\n{content}"
     );
+    assert_depth_warning(&result, 3);
 }
 
-/// With `max_depth: Some(0)`, no nodes are processed and the output is empty or whitespace only.
+/// Multiple truncated subtrees still produce one conversion-level warning.
+#[test]
+fn test_max_depth_warns_once_for_multiple_truncated_subtrees() {
+    let html = "<div><div><p>first</p></div><div><p>second</p></div></div>";
+    let options = ConversionOptions {
+        extract_metadata: false,
+        max_depth: Some(2),
+        ..Default::default()
+    };
+
+    let result = convert_with_options(html, options);
+    let content = result.content.as_deref().unwrap_or_default();
+    assert!(!content.contains("first"));
+    assert!(!content.contains("second"));
+    assert_depth_warning(&result, 2);
+}
+
+/// With `max_depth: Some(0)`, no nodes are processed and truncation is reported.
 #[test]
 fn test_max_depth_zero_produces_empty() {
     let html = "<p>hello</p>";
@@ -69,8 +97,88 @@ fn test_max_depth_zero_produces_empty() {
     };
 
     let result = convert_with_options(html, options);
+    let content = result.content.as_deref().unwrap_or_default();
     assert!(
-        result.trim().is_empty(),
-        "max_depth: Some(0) should produce no output. Got:\n{result}"
+        content.trim().is_empty(),
+        "max_depth: Some(0) should produce no output. Got:\n{content}"
     );
+    assert_depth_warning(&result, 0);
+}
+
+/// Tier-2 applies its native stack-safe limit when no explicit limit is configured.
+#[test]
+fn test_tier2_default_limit_truncates_and_warns() {
+    let html = format!("{}leaf{}", "<div>".repeat(65), "</div>".repeat(65));
+    let options = ConversionOptions {
+        extract_metadata: false,
+        max_depth: None,
+        tier_strategy: TierStrategy::Tier2,
+        ..Default::default()
+    };
+
+    let result = convert_with_options(&html, options);
+    let content = result.content.as_deref().unwrap_or_default();
+    assert!(!content.contains("leaf"));
+    assert_depth_warning(&result, 64);
+}
+
+/// Tier-2 processes every node below the default limit without warning.
+#[test]
+fn test_tier2_default_limit_boundary_does_not_warn() {
+    let html = format!("{}leaf{}", "<div>".repeat(63), "</div>".repeat(63));
+    let options = ConversionOptions {
+        extract_metadata: false,
+        max_depth: None,
+        tier_strategy: TierStrategy::Tier2,
+        ..Default::default()
+    };
+
+    let result = convert_with_options(&html, options);
+    assert!(result.content.as_deref().unwrap_or_default().contains("leaf"));
+    assert!(result.warnings.is_empty());
+}
+
+/// Explicit limits above the native stack-safe limit are clamped and report the effective value.
+#[test]
+fn test_max_depth_above_safety_limit_is_clamped() {
+    let html = format!("{}leaf{}", "<div>".repeat(65), "</div>".repeat(65));
+    let options = ConversionOptions {
+        extract_metadata: false,
+        max_depth: Some(usize::MAX),
+        ..Default::default()
+    };
+
+    let result = convert_with_options(&html, options);
+    assert!(!result.content.as_deref().unwrap_or_default().contains("leaf"));
+    assert_depth_warning(&result, 64);
+}
+
+/// Plain-text output reports the same default Tier-2 truncation as Markdown output.
+#[test]
+fn test_plain_text_default_limit_truncates_and_warns() {
+    let html = format!("{}leaf{}", "<div>".repeat(65), "</div>".repeat(65));
+    let options = ConversionOptions {
+        extract_metadata: false,
+        max_depth: None,
+        output_format: OutputFormat::Plain,
+        ..Default::default()
+    };
+
+    let result = convert_with_options(&html, options);
+    assert!(!result.content.as_deref().unwrap_or_default().contains("leaf"));
+    assert_depth_warning(&result, 64);
+}
+
+/// A tree whose deepest node is below the configured limit is not truncated.
+#[test]
+fn test_max_depth_below_limit_does_not_warn() {
+    let options = ConversionOptions {
+        extract_metadata: false,
+        max_depth: Some(3),
+        ..Default::default()
+    };
+
+    let result = convert_with_options("<div><p>safe</p></div>", options);
+    assert!(result.content.as_deref().unwrap_or_default().contains("safe"));
+    assert!(result.warnings.is_empty());
 }


### PR DESCRIPTION
## Related

Follow-up to #421.

## Description

Tier-2 already stops at the configured or stack-safe depth limit, but reaching it was not reported in `ConversionResult.warnings`.

**Root cause:** `walk_node` returned at the depth guard without recording that deeper nodes were skipped.

**Fix:** Track the limit in shared conversion context and append one `DepthLimitExceeded` warning after traversal. Multiple skipped subtrees still produce one warning, and existing warnings remain intact:

```text
DOM traversal reached the effective depth limit of {max_depth}; deeper nodes were skipped.
```

The Tier-1 router now sends explicit `max_depth` configurations to Tier-2 so the option is honored. CLI and MCP help also describe the native-stack safety limit accurately.

**Tests:** Added focused coverage for warning emission, effective limits, and non-truncating boundaries.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable
