### PR TITLE
feat(cli): add cargo-binstall support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1453,6 +1453,44 @@ jobs:
       build-musl: true
       checksums: true
 
+  verify-binstall:
+    name: Verify cargo-binstall install (${{ matrix.target }})
+    needs: [prepare, upload-cli-release]
+    if: ${{ needs.prepare.outputs.release_cli == 'true' && needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.dry_run != 'true' && needs.upload-cli-release.result == 'success' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          - { os: macos-latest, target: aarch64-apple-darwin }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc }
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: cargo-bins/cargo-binstall@v1.21.1
+
+      - name: Install CLI via cargo-binstall
+        shell: bash
+        run: |
+          cargo binstall html-to-markdown-cli \
+            --manifest-path crates/html-to-markdown-cli \
+            --target ${{ matrix.target }} \
+            --strategies crate-meta-data \
+            --no-confirm \
+            --log-level info
+
+      - name: Smoke-test installed binary
+        shell: bash
+        run: |
+          html-to-markdown --version
+          test "$(printf '<h1>Hello</h1>' | html-to-markdown)" = "# Hello"
+
   upload-go-release:
     name: Upload Go FFI archives to GitHub Release
     needs: [prepare, go-ffi-libraries]
@@ -2535,6 +2573,7 @@ jobs:
       - trigger-pubdev
       - publish-zig
       - upload-cli-release
+      - verify-binstall
       - upload-go-release
       - upload-c-ffi-release
       - upload-swift-release

--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ cargo install html-to-markdown-cli
 ```
 
 ```sh
+# Or install the prebuilt binary via cargo-binstall:
+cargo binstall html-to-markdown-cli
+```
+
+```sh
 brew install xberg-io/tap/html-to-markdown
 ```
 

--- a/crates/html-to-markdown-cli/Cargo.toml
+++ b/crates/html-to-markdown-cli/Cargo.toml
@@ -17,6 +17,13 @@ categories = ["command-line-utilities", "text-processing"]
 name = "html-to-markdown"
 path = "src/main.rs"
 
+# cargo-binstall support: release assets use a `cli-` prefix that doesn't match
+# binstall's default naming, so pin the download URL and bin-dir explicitly.
+# See https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/cli-{ target }{ archive-suffix }"
+bin-dir = "cli-{ target }/{ bin }{ binary-ext }"
+
 [features]
 default = ["mcp", "mcp-http"]
 mcp = ["html-to-markdown-rs/mcp", "dep:tokio"]

--- a/docs-site/src/content/docs/cli.mdx
+++ b/docs-site/src/content/docs/cli.mdx
@@ -12,6 +12,12 @@ The `html-to-markdown` CLI converts HTML files or URLs to Markdown from the comm
 cargo install html-to-markdown-cli
 ```
 
+Or grab the prebuilt binary via [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
+
+```bash
+cargo binstall html-to-markdown-cli
+```
+
 Or via Homebrew:
 
 ```bash

--- a/docs-site/src/content/docs/installation.mdx
+++ b/docs-site/src/content/docs/installation.mdx
@@ -469,10 +469,14 @@ If `pip install html-to-markdown` fails on Windows 11 with Python 3.14 or later,
 
 ## CLI
 
-Install via Cargo:
+Install via Cargo, or use [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) to grab the prebuilt binary from GitHub Releases:
 
 ```bash
 cargo install html-to-markdown-cli
+```
+
+```bash
+cargo binstall html-to-markdown-cli
 ```
 
 Or via Homebrew:

--- a/readme_templates/root.md
+++ b/readme_templates/root.md
@@ -208,6 +208,11 @@ cargo install html-to-markdown-cli
 ```
 
 ```sh
+# Or install the prebuilt binary via cargo-binstall:
+cargo binstall html-to-markdown-cli
+```
+
+```sh
 brew install xberg-io/tap/html-to-markdown
 ```
 


### PR DESCRIPTION
## Related

https://github.com/xberg-io/html-to-markdown/issues/447

## Description

Publish [package.metadata.binstall] for html-to-markdown-cli so `cargo binstall html-to-markdown-cli` resolves the prebuilt binaries from GitHub Releases (cli-{target}.tar.gz/.zip), which don't match binstall's default {name}-{target}-v{version} naming.

The release workflow now verifies the install on linux/macos/windows against freshly uploaded assets and gates release-finalize on it. Docs (README, docs-site) mention cargo binstall as an install option.

## Note

I've only verified this locally (dry-run resolution across targets plus a real install on macOS) and haven't exercised the actual repository release pipeline, so it would be greatly appreciated if you, as the maintainer, could test and refine this further where possible. Thank you!